### PR TITLE
Refine E2E tests

### DIFF
--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
         private readonly BlobContainerClient _blobContainerClient;
         private const string _configurationPath = "appsettings.test.json";
         private int _triggerIntervalInMinutes = 5;
+        private string _dateTimeFormat = "yyyy-MM-ddThh:mm:ssZ";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="E2ETests"/> class.
@@ -72,8 +73,8 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             // Load configuration and set endTime to yesterday
             var configuration = new ConfigurationBuilder().AddJsonFile(_configurationPath).Build();
             var now = DateTime.Now;
-            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["startTime"] = now.AddMinutes(-1 * _triggerIntervalInMinutes).ToString("yyyy-MM-ddThh:mm:ssZ");
-            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"] = now.ToString("yyyy-MM-ddThh:mm:ssZ");
+            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["startTime"] = now.AddMinutes(-1 * _triggerIntervalInMinutes).ToString(_dateTimeFormat);
+            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"] = now.ToString(_dateTimeFormat);
 
             // Run e2e
             var host = CreateHostBuilder(configuration).Build();

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
         private readonly BlobContainerClient _blobContainerClient;
         private const string _configurationPath = "appsettings.test.json";
         private int _triggerIntervalInMinutes = 5;
-        private string _dateTimeFormat = "yyyy-MM-ddThh:mm:ssZ";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="E2ETests"/> class.
@@ -72,9 +71,9 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
 
             // Load configuration and set endTime to yesterday
             var configuration = new ConfigurationBuilder().AddJsonFile(_configurationPath).Build();
-            var now = DateTime.Now;
-            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["startTime"] = now.AddMinutes(-1 * _triggerIntervalInMinutes).ToString(_dateTimeFormat);
-            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"] = now.ToString(_dateTimeFormat);
+            var now = DateTime.UtcNow;
+            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["startTime"] = now.AddMinutes(-1 * _triggerIntervalInMinutes).ToString("o");
+            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"] = now.ToString("o");
 
             // Run e2e
             var host = CreateHostBuilder(configuration).Build();

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
         private readonly BlobServiceClient _blobServiceClient;
         private readonly BlobContainerClient _blobContainerClient;
         private const string _configurationPath = "appsettings.test.json";
+        private int _triggerIntervalInMinutes = 5;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="E2ETests"/> class.
@@ -70,7 +71,9 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
 
             // Load configuration and set endTime to yesterday
             var configuration = new ConfigurationBuilder().AddJsonFile(_configurationPath).Build();
-            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"] = DateTime.Now.Date.ToString("yyyy-MM-dd");
+            var now = DateTime.Now;
+            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["startTime"] = now.AddMinutes(-1 * _triggerIntervalInMinutes).ToString("yyyy-MM-ddThh:mm:ssZ");
+            configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"] = now.ToString("yyyy-MM-ddThh:mm:ssZ");
 
             // Run e2e
             var host = CreateHostBuilder(configuration).Build();

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/appsettings.test.json
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/appsettings.test.json
@@ -8,8 +8,8 @@
   },
   "job": {
     "containerName": "test",
-    "startTime": "1970-01-01T00:00:00Z",
-    "endTime": "2021-12-01T00:00:00Z",
+    "startTime": "1970-01-01T00:00:00.000Z",
+    "endTime": "2021-12-01T00:00:00.000Z",
     "resourceTypeFilters": [
       "Patient",
       "Observation"

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/appsettings.test.json
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/appsettings.test.json
@@ -8,8 +8,8 @@
   },
   "job": {
     "containerName": "test",
-    "startTime": "2000-09-01",
-    "endTime": "2000-10-01",
+    "startTime": "1970-01-01T00:00:00Z",
+    "endTime": "2021-12-01T00:00:00Z",
     "resourceTypeFilters": [
       "Patient",
       "Observation"


### PR DESCRIPTION
Refine mock FHIR Server and E2E tests from FHIR Server to Storage to be aligned with real Azure FunctionApp trigger, which is needed by E2E tests from FHIR Server to Synapse.