### PR TITLE
Disable function RunOnStartup

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/JobManagerFunction.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/JobManagerFunction.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Synapse.FunctionApp
 
         [Function("JobManagerFunction")]
         public async Task Run(
-            [TimerTrigger("0 */5 * * * *", RunOnStartup = true)] MyInfo myTimer,
+            [TimerTrigger("0 */5 * * * *", RunOnStartup = false)] MyInfo myTimer,
             FunctionContext context)
         {
             var logger = context.GetLogger("JobManagerFunction");


### PR DESCRIPTION
Disable function time trigger RunOnStartup,

RunOnStartup=True may leading code execute at highly unpredictable times. See https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer?tabs=csharp#configuration