### PR TITLE
Enable hierarchical namespace in storage v2 template

### DIFF
--- a/FhirToDataLake/deploy/templates/FhirSynapsePipelineTemplate.json
+++ b/FhirToDataLake/deploy/templates/FhirSynapsePipelineTemplate.json
@@ -108,6 +108,9 @@
             "sku": {
                 "name": "[parameters('storageAccountType')]"
             },
+            "properties": {
+                "isHnsEnabled": true
+            },
             "kind": "StorageV2"
         },
         {


### PR DESCRIPTION
Hierarchical namespace is not enabled by default in storage v2 deployment.
We need to specify the option explicitly in the arm template.