### PR TITLE
Update Deploy to Azure button image

### DIFF
--- a/FhirToDataLake/docs/Deployment.md
+++ b/FhirToDataLake/docs/Deployment.md
@@ -32,7 +32,7 @@ This solution enables you to query against the entire FHIR data with tools such 
 1. To deploy the FHIR Synapse sync pipeline, use the buttons below to deploy through the Azure Portal.
    
     <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FFHIR-Analytics-Pipelines%2Fmain%2FFhirToDataLake%2Fdeploy%2Ftemplates%2FFhirSynapsePipelineTemplate.json" target="_blank">
-        <img src="https://azuredeploy.net/deploybutton.png"/>
+        <img src="https://aka.ms/deploytoazurebutton"/>
     </a>
 
     Or you can browse to the [Custom deployment](https://ms.portal.Azure.com/#create/Microsoft.Template) page in the Azure portal, select **Build your own template in the editor**, then copy the content of the provided [ARM template](../deploy/templates/FhirSynapsePipelineTemplate.json) to the edit box and click **Save**.


### PR DESCRIPTION
In [deployment](https://github.com/microsoft/FHIR-Analytics-Pipelines/blob/main/FhirToDataLake/docs/Deployment.md) page, **Deploy to Azure** button is crush from my side due to the security certificate error, the newest document [Deploy on github](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-to-azure-button) recommends to use **https://aka.ms/deploytoazurebutton** as the button image.

 
![image](https://user-images.githubusercontent.com/68055742/150076873-1d6430d4-b079-48ac-9407-ebe09f14ab9e.png)


![image](https://user-images.githubusercontent.com/68055742/150076511-d1f976e7-36ec-40eb-aa4a-3092522451e3.png)
