### PR TITLE
Personal/quwan/update fhir to cdm npm ci

### DIFF
--- a/FhirToCdm/docs/fhir-to-cdm.md
+++ b/FhirToCdm/docs/fhir-to-cdm.md
@@ -16,7 +16,7 @@ Table configuration generator takes YAML instructions from user and generates a 
 
 First, ensure you already have Node.js and npm installed, see [Downloading and installing Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) if they don't exist
 
-Then clone this FHIR-Analytics-Pipelines repo to your local machine, browse to the ```Configuration-Generator``` directory, use commands below to install the dependencies. 
+Then clone this [FHIR-Analytics-Pipelines](https://github.com/microsoft/FHIR-Analytics-Pipelines) repo to your local machine, browse to the ```FhirToCdm\Configuration-Generator``` directory, use command below to install the dependencies. 
 ```
 npm ci
 ```

--- a/FhirToCdm/docs/fhir-to-cdm.md
+++ b/FhirToCdm/docs/fhir-to-cdm.md
@@ -14,11 +14,20 @@ The FHIR to CDM tool has three components, shown in green in the diagram below:
 
 Table configuration generator takes YAML instructions from user and generates a table configuration folder. The schema viewer, described later, helps visualize the schema of the generated tables.
 
-First, use `npm install` to install the dependencies. Subsequently, you can run the following command from the _Configuration-Generator_ folder to generate table configuration. You may use the sample yaml files, [_resourcesConfig.yml_](../Configuration-Generator/resourcesConfig.yml) and [_propertiesGroupConfig.yml_](../Configuration-Generator/propertiesGroupConfig.yml) provided in the project. See the [YAML instructions format](yaml-instructions-format.md) document if you want to write yaml instructions as per your needs.
+First, ensure you already have Node.js and npm installed, see [Downloading and installing Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) if they don't exist
 
-```Configuration-Generator> node .\generate_from_yaml.js -r {resource configuration file} -p {properties group file} -o {output folder}```
+Then clone this FHIR-Analytics-Pipelines repo to your local machine, browse to the ```Configuration-Generator``` directory, use commands below to install the dependencies. 
+```
+npm ci
+```
 
-Example:
+Subsequently, you can run the following command from the _Configuration-Generator_ folder to generate table configuration. You may use the sample yaml files, [_resourcesConfig.yml_](../Configuration-Generator/resourcesConfig.yml) and [_propertiesGroupConfig.yml_](../Configuration-Generator/propertiesGroupConfig.yml) provided in the project. See the [YAML instructions format](yaml-instructions-format.md) document if you want to write yaml instructions as per your needs.
+
+```
+Configuration-Generator> node .\generate_from_yaml.js -r {resource configuration file} -p {properties group file} -o {output folder}
+```
+
+Example: 
 
 ```Configuration-Generator> node .\generate_from_yaml.js -r resourcesConfig.yml -p propertiesGroupConfig.yml -o tableConfig```
 


### PR DESCRIPTION
Update ```npm install``` to ```npm ci``` when users install dependencies, the latter is more recommended when ```package-lock.json``` and ```package.json``` both provided, see https://docs.npmjs.com/cli/v8/commands/npm-ci