### PR TITLE
Conditions in Release stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,9 +40,13 @@ stages:
     - template: FhirToDataLake/synapse-e2e-test.yml
 
   - job: PublishFhirToCdm
+    dependsOn: SynapseE2ETest
+    condition: succeeded()
     steps:
     - template: FhirToCdm/publish.yml
 
   - job: PublishArtifactsToGitHub
+    dependsOn: PublishFhirToCdm
+    condition: succeeded()
     steps:
     - template: publish.yml


### PR DESCRIPTION
Add conditions in azure pipeline ```Release``` stage.

Multiple jobs may been built in parallel if set up multiple agents, see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#dependencies