### PR TITLE
Fix private NuGet source

### DIFF
--- a/FhirToDataLake/NuGet.Config
+++ b/FhirToDataLake/NuGet.Config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="yanhon" value="https://microsofthealth.pkgs.visualstudio.com/Health/_packaging/yanhon/nuget/v3/index.json" />
+    <add key="FhirAnalyticsPublic" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirAnalytics/_packaging/FhirAnalyticsPublic/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The `NuGet.Config` file currently references a private nuget source, which will raise authorization errors when restoring packages. Now we change to a public NuGet source.