### PR TITLE
Force upload package in devOps pipeline

### DIFF
--- a/FhirToDataLake/synapse-e2e-test.yml
+++ b/FhirToDataLake/synapse-e2e-test.yml
@@ -31,7 +31,7 @@ steps:
       $storageAccountKey = (Get-AzStorageAccountKey -ResourceGroupName $(resourceGroup) -AccountName $(storageName)).Value[0]
       $storageContext = New-AzStorageContext -StorageAccountName $(storageName) -StorageAccountKey $storageAccountKey
       $blobName = '$(appName)' + 'FunctionApp.zip'
-      Set-AzStorageBlobContent -Container $(packageContainer) -Context $storageContext -File $(Build.ArtifactStagingDirectory)/FhirToDataLakeBuild/Microsoft.Health.Fhir.Synapse.FunctionApp.zip -Blob $blobName
+      Set-AzStorageBlobContent -Container $(packageContainer) -Context $storageContext -File $(Build.ArtifactStagingDirectory)/FhirToDataLakeBuild/Microsoft.Health.Fhir.Synapse.FunctionApp.zip -Blob $blobName -Force
 
       # Get and set up SAS of Function.zip
       $packageUrl = New-AzStorageBlobSASToken -Context $storageContext -Container $(packageContainer) -Blob $blobName -Permission r -FullUri


### PR DESCRIPTION
Add ```-Force``` when upload package to storage in synapse-e2e-test pipeline.

Currently if job failed but has already uploaded zip package to storage, re-try will always fail because ```Set-AzStorageBlobContent``` command need to confirm whether to overwrite exist blob, but pipeline is not run in interactive mod.

![image](https://user-images.githubusercontent.com/68055742/155666064-adcb96ab-def4-4819-ba78-d2ab2292c4d3.png)
