### PR TITLE
Add nuget public source

### DIFF
--- a/FhirToDataLake/NuGet.Config
+++ b/FhirToDataLake/NuGet.Config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="FhirAnalyticsPublic" value="https://microsofthealthoss.pkgs.visualstudio.com/FhirAnalytics/_packaging/FhirAnalyticsPublic/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We should add the public nuget source to nuget.conf explicitly as upstream sources are not supported for public feeds. [Reference](https://docs.microsoft.com/en-us/azure/devops/artifacts/concepts/upstream-sources?view=azure-devops#best-practices-feed-ownerspackage-publishers)