### PR TITLE
Add global.json

### DIFF
--- a/FhirToDataLake/global.json
+++ b/FhirToDataLake/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "5.0.403",
+      "rollForward": "latestFeature"
+    }
+  }


### PR DESCRIPTION
Currently we may face local build issues when having a newer SDK than the one included in Visual Studio for C++/CLI projects, specifying the .NET SDK version will help mitigate the issue.