### PR TITLE
Fix FHIR server URL missing trailing slash issue

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
             ILogger<FhirApiDataClient> logger)
         {
             EnsureArg.IsNotNull(dataSource, nameof(dataSource));
+            EnsureArg.IsNotNullOrEmpty(dataSource.FhirServerUrl, nameof(dataSource.FhirServerUrl));
             EnsureArg.IsNotNull(httpClient, nameof(httpClient));
             EnsureArg.IsNotNull(accessTokenProvider, nameof(accessTokenProvider));
             EnsureArg.IsNotNull(logger, nameof(logger));
@@ -94,7 +95,16 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
         /// <returns>Uri with search parameters.</returns>
         private Uri CreateSearchUri(FhirSearchParameters searchParameters)
         {
-            var baseUri = new Uri(_dataSource.FhirServerUrl);
+            // If the baseUri has relative parts (like /api),
+            // then the relative part must be terminated with a slash, (like /api/),
+            // if the relative part of baseUri is to be preserved in the constructed Uri. See https://docs.microsoft.com/en-us/dotnet/api/system.uri.-ctor?view=net-6.0
+            var serverUrl = _dataSource.FhirServerUrl;
+            if (!_dataSource.FhirServerUrl.EndsWith("/"))
+            {
+                serverUrl = $"{_dataSource.FhirServerUrl}/";
+            }
+
+            var baseUri = new Uri(serverUrl);
             var uri = new Uri(baseUri, searchParameters.ResourceType);
 
             var queryParameters = new List<KeyValuePair<string, string>>

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
@@ -95,9 +95,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
         /// <returns>Uri with search parameters.</returns>
         private Uri CreateSearchUri(FhirSearchParameters searchParameters)
         {
-            // If the baseUri has relative parts (like /api),
-            // then the relative part must be terminated with a slash, (like /api/),
-            // if the relative part of baseUri is to be preserved in the constructed Uri. See https://docs.microsoft.com/en-us/dotnet/api/system.uri.-ctor?view=net-6.0
+            // If the baseUri has relative parts (like /api), then the relative part must be terminated with a slash (like /api/).
+            // Otherwise the relative part will be omitted when creating new search Uris. See https://docs.microsoft.com/en-us/dotnet/api/system.uri.-ctor?view=net-6.0
             var serverUrl = _dataSource.FhirServerUrl;
             if (!_dataSource.FhirServerUrl.EndsWith("/"))
             {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataSource.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataSource.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
         public FhirApiDataSource(IOptions<FhirServerConfiguration> config)
         {
             EnsureArg.IsNotNull(config, nameof(config));
+            EnsureArg.IsNotNullOrEmpty(config.Value.ServerUrl, nameof(config.Value.ServerUrl));
 
             FhirServerUrl = config.Value.ServerUrl;
             Authentication = config.Value.Authentication;


### PR DESCRIPTION
If the base FHIR server [Uri](https://docs.microsoft.com/en-us/dotnet/api/system.uri?view=net-6.0) has relative parts and the relative part does not end with a trailing slash  (like /api) , then the relative part will be omitted when composing a FHIR search uri. In this pull request, we always append a trailing slash to the FHIR base uri if the trailing slash is not present.