### PR TITLE
Fix data lake client error when parsing data lake storage endpoints.

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataWriter/Microsoft.Health.Fhir.Synapse.DataWriter.csproj
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataWriter/Microsoft.Health.Fhir.Synapse.DataWriter.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Fhir.Synapse.Common\Microsoft.Health.Fhir.Synapse.Common.csproj" />
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
-    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.8.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
+    <PackageReference Include="Azure.Storage.Files.DataLake" Version="12.9.0" />
     <PackageReference Include="Ensure.That" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Currently the referenced data lake client may convert dfs and blob endpoints incorrectly, which can break the pipeline when committing the staged data. Update the library version to fix the unexpected behavior.

For more details, see the [pull request link](https://github.com/Azure/azure-sdk-for-net/commit/8406d81100e9ba3b171fdf9d08896756e1e4132a).