### PR TITLE
Upgrade newtonsoft.json 13.0.1

### DIFF
--- a/FhirToCdm/Microsoft.CommonDataModel.ObjectModel.Adapter.Adls/Microsoft.CommonDataModel.ObjectModel.Adapter.Adls.csproj
+++ b/FhirToCdm/Microsoft.CommonDataModel.ObjectModel.Adapter.Adls/Microsoft.CommonDataModel.ObjectModel.Adapter.Adls.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/FhirToCdm/Microsoft.CommonDataModel.ObjectModel/Microsoft.CommonDataModel.ObjectModel.csproj
+++ b/FhirToCdm/Microsoft.CommonDataModel.ObjectModel/Microsoft.CommonDataModel.ObjectModel.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
 

--- a/FhirToCdm/Microsoft.Health.Fhir.Transformation.Cdm.Test/Microsoft.Health.Fhir.Transformation.Cdm.Test.csproj
+++ b/FhirToCdm/Microsoft.Health.Fhir.Transformation.Cdm.Test/Microsoft.Health.Fhir.Transformation.Cdm.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 

--- a/FhirToCdm/Microsoft.Health.Fhir.Transformation.Core/Microsoft.Health.Fhir.Transformation.Core.csproj
+++ b/FhirToCdm/Microsoft.Health.Fhir.Transformation.Core/Microsoft.Health.Fhir.Transformation.Core.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Hl7.Fhir.R4" Version="1.9.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Combine the robot PRs to upgrade Newtonsoft version.
The pipeline tests failed for individual updates due to dependency issue.