### PR TITLE
Set up service principal as environment credential

### DIFF
--- a/FhirToDataLake/build.yml
+++ b/FhirToDataLake/build.yml
@@ -48,13 +48,6 @@ steps:
     SecretsFilter: '*'
     RunAsPreJob: false
 
-- task: PowerShell@2
-  displayName: Login Azure Account
-  inputs:
-    targetType: 'inline'
-    script: |
-      az login -u $(pipeline-service-principal-name) -p $(pipeline-service-principal-password) --service-principal --tenant $(pipeline-tenant-id)
-
 - task: VSTest@2
   displayName: 'Run native tests'
   inputs:
@@ -82,14 +75,9 @@ steps:
   env:
     TestContainerRegistryServer: $(pipeline-container-registry-server)
     TestContainerRegistryPassword: $(pipeline-container-registry-password)
-
-- task: PowerShell@2
-  displayName: Logout Azure Account
-  inputs:
-    targetType: 'inline'
-    script: |
-      az logout
-      Write-Host "Cleared Azure Account successfully."
+    AZURE_CLIENT_ID: $(pipeline-service-principal-name)
+    AZURE_CLIENT_SECRET: $(pipeline-service-principal-password)
+    AZURE_TENANT_ID: $(pipeline-tenant-id)
 
 - task: Docker@2
   displayName: Stop mock-data-source

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryTemplateProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryTemplateProviderTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
 
             var testContainerRegistryUsername = Environment.GetEnvironmentVariable("TestContainerRegistryServer")?.Split('.')[0];
             var testContainerRegistryPassword = Environment.GetEnvironmentVariable("TestContainerRegistryPassword");
-            Console.WriteLine($"Password length: {testContainerRegistryPassword.Length}");
 
             _testContainerRegistryAccessToken = GetContainerRegistryAccessToken(testContainerRegistryUsername, testContainerRegistryPassword);
         }


### PR DESCRIPTION
The **DefaultAzureCredential** will try to get the following credential types in order:

[EnvironmentCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet)
[ManagedIdentityCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential?view=azure-dotnet)
[SharedTokenCacheCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.sharedtokencachecredential?view=azure-dotnet)
[VisualStudioCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocredential?view=azure-dotnet)
[VisualStudioCodeCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.visualstudiocodecredential?view=azure-dotnet)
[AzureCliCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.azureclicredential?view=azure-dotnet)
[AzurePowerShellCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.azurepowershellcredential?view=azure-dotnet)
[InteractiveBrowserCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.interactivebrowsercredential?view=azure-dotnet)

Set up the principal account as environment variables been accessed by  [EnvironmentCredential](https://docs.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet) in DevOps pipeline test, to avoid it being overwritten by other credentials.