### PR TITLE
Fix AzureBlobContainerTests using same stream

### DIFF
--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/Azure/AzureBlobContainerClientTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/Azure/AzureBlobContainerClientTests.cs
@@ -337,8 +337,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             Assert.False(blobClient.Exists());
 
-            using MemoryStream sourceStream = new MemoryStream();
-            using StreamWriter writer = new StreamWriter(sourceStream);
+            using MemoryStream sourceStream_1 = new MemoryStream();
+            using StreamWriter writer = new StreamWriter(sourceStream_1);
 
             int lineNumber = (1024 * 1024) + 3;
             while (lineNumber-- > 0)
@@ -348,10 +348,16 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             await writer.FlushAsync();
 
-            sourceStream.Position = 0;
+            sourceStream_1.Position = 0;
 
-            var task_1 = blobProvider.CreateBlobAsync(blobName, sourceStream, CancellationToken.None);
-            var task_2 = blobProvider.CreateBlobAsync(blobName, sourceStream, CancellationToken.None);
+            using MemoryStream sourceStream_2 = new MemoryStream();
+            sourceStream_1.CopyTo(sourceStream_2);
+
+            sourceStream_1.Position = 0;
+            sourceStream_2.Position = 0;
+
+            var task_1 = blobProvider.CreateBlobAsync(blobName, sourceStream_1, CancellationToken.None);
+            var task_2 = blobProvider.CreateBlobAsync(blobName, sourceStream_2, CancellationToken.None);
 
             var isCreateds = await Task.WhenAll(task_1, task_2);
 


### PR DESCRIPTION
I find a unit test will try to use same stream to test an interface ```CreateBlobAsync(string blobName, Stream stream, CancellationToken cancellationToken = default)```, which may lead to thread issue.

```
  stream.Seek(0, SeekOrigin.Begin);
  try
  {
      await blobClient.UploadAsync(stream, cancellationToken);
      _logger.LogInformation("Created blob '{0}' successfully.", blobName);

      return true;
  }
```