### PR TITLE
Set the data repeat count to 50 in unit test

### DIFF
--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/ParquetDataProcessorTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/ParquetDataProcessorTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
         public async Task GivenAValidMultipleLargeInputData_WhenProcess_CorrectResultShouldBeReturned()
         {
             var largePatientSingleSet = TestUtils.LoadNdjsonData(Path.Combine(TestUtils.TestDataFolder, "Large_Patient.ndjson"));
-            var largeTestData = Enumerable.Repeat(largePatientSingleSet, 100).SelectMany(x => x);
+            var largeTestData = Enumerable.Repeat(largePatientSingleSet, 50).SelectMany(x => x);
 
             var jsonBatchData = new JsonBatchData(largeTestData);
 


### PR DESCRIPTION
Current unit test will trigger an out of memory error.

The DevOps pipeline default agents that run Windows are provisioned on Azure general purpose virtual machines with 7 GB of RAM refer to [Hardware](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#hardware), and our unit test take 7 GB memory in my local test.