### PR TITLE
Add config versioning

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationConstants.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationConstants.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations
 {
     public static class ConfigurationConstants
     {
+        public const string ConfigVersionKey = "configVersion";
+
         public const string JobConfigurationKey = "job";
 
         public const string FilterConfigurationKey = "filter";

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationResolvers/ConfigurationResolverV1.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationResolvers/ConfigurationResolverV1.cs
@@ -1,0 +1,40 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Synapse.Common.Configurations.Arrow;
+
+namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationResolvers
+{
+    public class ConfigurationResolverV1
+    {
+        public static void Resolve(
+            IServiceCollection services,
+            IConfiguration configuration)
+        {
+            services.Configure<FhirServerConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.FhirServerConfigurationKey).Bind(options));
+            services.Configure<JobConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.JobConfigurationKey).Bind(options));
+            services.Configure<FilterConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.FilterConfigurationKey).Bind(options));
+            services.Configure<FilterLocation>(options =>
+                configuration.GetSection(ConfigurationConstants.FilterConfigurationKey).Bind(options));
+            services.Configure<DataLakeStoreConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.DataLakeStoreConfigurationKey).Bind(options));
+            services.Configure<ArrowConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.ArrowConfigurationKey).Bind(options));
+            services.Configure<JobSchedulerConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.SchedulerConfigurationKey).Bind(options));
+            services.Configure<SchemaConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.SchemaConfigurationKey).Bind(options));
+            services.Configure<HealthCheckConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.HealthCheckConfigurationKey).Bind(options));
+            services.Configure<StorageConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.StorageConfigurationKey).Bind(options));
+        }
+    }
+}

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ConfigurationValidatorV1.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ConfigurationValidatorV1.cs
@@ -4,24 +4,21 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using EnsureThat;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.Health.Fhir.Synapse.Common.Configurations;
 using Microsoft.Health.Fhir.Synapse.Common.Exceptions;
-using Microsoft.Health.Fhir.Synapse.Common.Models.Jobs;
 
-namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
+namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValidators
 {
-    public static class ServiceCollectionExtensions
+    public static class ConfigurationValidatorV1
     {
         /// <summary>
         /// Validate configuration in service collection.
         /// </summary>
         /// <param name="services">Service collection instance.</param>
         /// <exception cref="ConfigurationErrorException">Throw ConfigurationErrorException if configuration is invalid.</exception>
-        public static void ValidateConfiguration(this IServiceCollection services)
+        public static void Validate(IServiceCollection services)
         {
             FhirServerConfiguration fhirServerConfiguration;
             try
@@ -60,9 +57,9 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
                 throw new ConfigurationErrorException("Failed to parse job configuration", ex);
             }
 
-            ValidateQueueOrTableName(jobConfiguration.JobInfoQueueName);
-            ValidateQueueOrTableName(jobConfiguration.JobInfoTableName);
-            ValidateQueueOrTableName(jobConfiguration.MetadataTableName);
+            ValidateUtility.ValidateQueueOrTableName(jobConfiguration.JobInfoQueueName);
+            ValidateUtility.ValidateQueueOrTableName(jobConfiguration.JobInfoTableName);
+            ValidateUtility.ValidateQueueOrTableName(jobConfiguration.MetadataTableName);
 
             EnsureArg.EnumIsDefined(jobConfiguration.QueueType, nameof(jobConfiguration.QueueType));
 
@@ -106,7 +103,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
                     throw new ConfigurationErrorException($"Filter image reference can not be empty when external filter configuration is enable.");
                 }
 
-                ValidateImageReference(filterLocation.FilterImageReference);
+                ValidateUtility.ValidateImageReference(filterLocation.FilterImageReference);
 
                 if (string.IsNullOrWhiteSpace(filterLocation.FilterConfigurationFileName))
                 {
@@ -128,7 +125,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
                     throw new ConfigurationErrorException("Failed to parse filter configuration", ex);
                 }
 
-                ValidateFilterConfiguration(filterConfiguration);
+                ValidateUtility.ValidateFilterConfiguration(filterConfiguration);
             }
 
             var storeConfiguration = services
@@ -162,7 +159,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
                 }
                 else
                 {
-                    ValidateImageReference(schemaConfiguration.SchemaImageReference);
+                    ValidateUtility.ValidateImageReference(schemaConfiguration.SchemaImageReference);
                 }
             }
             else
@@ -191,108 +188,6 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
                 healthCheckConfiguration.HealthCheckTimeIntervalInSeconds < healthCheckConfiguration.HealthCheckTimeoutInSeconds)
             {
                 throw new ConfigurationErrorException("Invalid health check configuration. Health check time interval should be greater than health check timeout and both of them should greater than zero.");
-            }
-        }
-
-        // Validate queue or table name to contain only alphanumeric characters, and not begin with a numeric character.
-        // Reference: https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-the-table-service-data-model#table-names
-        // https://docs.microsoft.com/en-us/rest/api/storageservices/naming-queues-and-metadata#queue-names
-        public static void ValidateQueueOrTableName(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                throw new ConfigurationErrorException("Queue or table name can not be empty.");
-            }
-
-            if (!name.All(char.IsLetterOrDigit))
-            {
-                throw new ConfigurationErrorException("Queue or table name may contain only alphanumeric characters.");
-            }
-
-            if (!char.IsLetter(name.First()))
-            {
-                throw new ConfigurationErrorException("Queue or table name should begin with an alphabet character.");
-            }
-
-            // The table/queue name must be from 3 to 63 characters long.
-            if (name.Length < 3 || name.Length > 63)
-            {
-                throw new ConfigurationErrorException("Queue or table name should be from 3 to 63 characters long.");
-            }
-        }
-
-        /// <summary>
-        /// Validate the image reference.
-        /// Image reference pattern: <registry>/<name>@<digest> or <registry>/<name>:<tag>
-        /// E.g. testacr.azurecr.io/templatetest@sha256:412ea84f1bb1a9d98345efb7b427ba89616ec29ac332d543eff9a2161ca12a58
-        /// </summary>
-        /// <param name="imageReference">Image reference</param>
-        /// <exception cref="ConfigurationErrorException">Throw ConfigurationErrorException if imageReference is invalid</exception>
-        public static void ValidateImageReference(string imageReference)
-        {
-            var registryDelimiterPosition = imageReference.IndexOf(ConfigurationConstants.ImageRegistryDelimiter, StringComparison.InvariantCultureIgnoreCase);
-            if (registryDelimiterPosition <= 0 || registryDelimiterPosition == imageReference.Length - 1)
-            {
-                throw new ConfigurationErrorException("Customized schema image format is invalid: registry server is missing.");
-            }
-
-            imageReference = imageReference[(registryDelimiterPosition + 1) ..];
-            string imageName = imageReference;
-            if (imageReference.Contains(ConfigurationConstants.ImageDigestDelimiter, StringComparison.OrdinalIgnoreCase))
-            {
-                Tuple<string, string> imageMeta = ParseImageMeta(imageReference, ConfigurationConstants.ImageDigestDelimiter);
-                if (string.IsNullOrEmpty(imageMeta.Item1) || string.IsNullOrEmpty(imageMeta.Item2))
-                {
-                    throw new ConfigurationErrorException("Customized schema image format is invalid: digest is missing.");
-                }
-
-                imageName = imageMeta.Item1;
-            }
-            else if (imageReference.Contains(ConfigurationConstants.ImageTagDelimiter, StringComparison.OrdinalIgnoreCase))
-            {
-                Tuple<string, string> imageMeta = ParseImageMeta(imageReference, ConfigurationConstants.ImageTagDelimiter);
-                if (string.IsNullOrEmpty(imageMeta.Item1) || string.IsNullOrEmpty(imageMeta.Item2))
-                {
-                    throw new ConfigurationErrorException("Customized schema image reference format is invalid: tag is missing.");
-                }
-
-                imageName = imageMeta.Item1;
-            }
-
-            ValidateImageName(imageName);
-        }
-
-        private static Tuple<string, string> ParseImageMeta(string input, char delimiter)
-        {
-            var index = input.IndexOf(delimiter, StringComparison.InvariantCultureIgnoreCase);
-            return new Tuple<string, string>(input[0..index], input[(index + 1) ..]);
-        }
-
-        private static void ValidateImageName(string imageName)
-        {
-            if (!ConfigurationConstants.ImageNameRegex.IsMatch(imageName))
-            {
-                throw new ConfigurationErrorException(
-                    $"Customized schema image name is invalid. Image name should contains lowercase letters, digits and separators. The valid format is {ConfigurationConstants.ImageNameRegex}");
-            }
-        }
-
-        /// <summary>
-        /// Validate FilterConfiguration.
-        /// </summary>
-        /// <param name="filterConfiguration">FilterConfiguration instance.</param>
-        /// <exception cref="ConfigurationErrorException">Throw ConfigurationErrorException if filterConfiguration is invalid.</exception>
-        public static void ValidateFilterConfiguration(FilterConfiguration filterConfiguration)
-        {
-            if (!Enum.IsDefined(typeof(FilterScope), filterConfiguration.FilterScope))
-            {
-                throw new ConfigurationErrorException(
-                    $"Filter Scope '{filterConfiguration.FilterScope}' is not supported.");
-            }
-
-            if (filterConfiguration.FilterScope == FilterScope.Group && string.IsNullOrWhiteSpace(filterConfiguration.GroupId))
-            {
-                throw new ConfigurationErrorException("Group id can not be null, empty or white space for `Group` filter scope.");
             }
         }
     }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ValidateUtility.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ValidateUtility.cs
@@ -1,0 +1,117 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using Microsoft.Health.Fhir.Synapse.Common.Exceptions;
+using Microsoft.Health.Fhir.Synapse.Common.Models.Jobs;
+
+namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValidators
+{
+    public static class ValidateUtility
+    {
+        /// <summary>
+        /// Validate FilterConfiguration.
+        /// </summary>
+        /// <param name="filterConfiguration">FilterConfiguration instance.</param>
+        /// <exception cref="ConfigurationErrorException">Throw ConfigurationErrorException if filterConfiguration is invalid.</exception>
+        public static void ValidateFilterConfiguration(FilterConfiguration filterConfiguration)
+        {
+            if (!Enum.IsDefined(typeof(FilterScope), filterConfiguration.FilterScope))
+            {
+                throw new ConfigurationErrorException(
+                    $"Filter Scope '{filterConfiguration.FilterScope}' is not supported.");
+            }
+
+            if (filterConfiguration.FilterScope == FilterScope.Group && string.IsNullOrWhiteSpace(filterConfiguration.GroupId))
+            {
+                throw new ConfigurationErrorException("Group id can not be null, empty or white space for `Group` filter scope.");
+            }
+        }
+
+        // Validate queue or table name to contain only alphanumeric characters, and not begin with a numeric character.
+        // Reference: https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-the-table-service-data-model#table-names
+        // https://docs.microsoft.com/en-us/rest/api/storageservices/naming-queues-and-metadata#queue-names
+        public static void ValidateQueueOrTableName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ConfigurationErrorException("Queue or table name can not be empty.");
+            }
+
+            if (!name.All(char.IsLetterOrDigit))
+            {
+                throw new ConfigurationErrorException("Queue or table name may contain only alphanumeric characters.");
+            }
+
+            if (!char.IsLetter(name.First()))
+            {
+                throw new ConfigurationErrorException("Queue or table name should begin with an alphabet character.");
+            }
+
+            // The table/queue name must be from 3 to 63 characters long.
+            if (name.Length < 3 || name.Length > 63)
+            {
+                throw new ConfigurationErrorException("Queue or table name should be from 3 to 63 characters long.");
+            }
+        }
+
+        /// <summary>
+        /// Validate the image reference.
+        /// Image reference pattern: <registry>/<name>@<digest> or <registry>/<name>:<tag>
+        /// E.g. testacr.azurecr.io/templatetest@sha256:412ea84f1bb1a9d98345efb7b427ba89616ec29ac332d543eff9a2161ca12a58
+        /// </summary>
+        /// <param name="imageReference">Image reference.</param>
+        /// <exception cref="ConfigurationErrorException">Throw ConfigurationErrorException if imageReference is invalid</exception>
+        public static void ValidateImageReference(string imageReference)
+        {
+            var registryDelimiterPosition = imageReference.IndexOf(ConfigurationConstants.ImageRegistryDelimiter, StringComparison.InvariantCultureIgnoreCase);
+            if (registryDelimiterPosition <= 0 || registryDelimiterPosition == imageReference.Length - 1)
+            {
+                throw new ConfigurationErrorException("Customized schema image format is invalid: registry server is missing.");
+            }
+
+            imageReference = imageReference[(registryDelimiterPosition + 1) ..];
+            string imageName = imageReference;
+            if (imageReference.Contains(ConfigurationConstants.ImageDigestDelimiter, StringComparison.OrdinalIgnoreCase))
+            {
+                Tuple<string, string> imageMeta = ParseImageMeta(imageReference, ConfigurationConstants.ImageDigestDelimiter);
+                if (string.IsNullOrEmpty(imageMeta.Item1) || string.IsNullOrEmpty(imageMeta.Item2))
+                {
+                    throw new ConfigurationErrorException("Customized schema image format is invalid: digest is missing.");
+                }
+
+                imageName = imageMeta.Item1;
+            }
+            else if (imageReference.Contains(ConfigurationConstants.ImageTagDelimiter, StringComparison.OrdinalIgnoreCase))
+            {
+                Tuple<string, string> imageMeta = ParseImageMeta(imageReference, ConfigurationConstants.ImageTagDelimiter);
+                if (string.IsNullOrEmpty(imageMeta.Item1) || string.IsNullOrEmpty(imageMeta.Item2))
+                {
+                    throw new ConfigurationErrorException("Customized schema image reference format is invalid: tag is missing.");
+                }
+
+                imageName = imageMeta.Item1;
+            }
+
+            ValidateImageName(imageName);
+        }
+
+        private static Tuple<string, string> ParseImageMeta(string input, char delimiter)
+        {
+            var index = input.IndexOf(delimiter, StringComparison.InvariantCultureIgnoreCase);
+            return new Tuple<string, string>(input[0..index], input[(index + 1) ..]);
+        }
+
+        private static void ValidateImageName(string imageName)
+        {
+            if (!ConfigurationConstants.ImageNameRegex.IsMatch(imageName))
+            {
+                throw new ConfigurationErrorException(
+                    $"Customized schema image name is invalid. Image name should contains lowercase letters, digits and separators. The valid format is {ConfigurationConstants.ImageNameRegex}");
+            }
+        }
+    }
+}

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/SupportedConfigVersion.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/SupportedConfigVersion.cs
@@ -1,0 +1,18 @@
+﻿// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Health.Fhir.Synapse.Common.Configurations
+{
+    /// <summary>
+    /// Supported versions for configurations.
+    /// </summary>
+    public enum SupportedConfigVersion
+    {
+        /// <summary>
+        /// First version.
+        /// </summary>
+        V1 = 1,
+    }
+}

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Extensions/ConfigurationRegistrationExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Extensions/ConfigurationRegistrationExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
 
             switch (configVersion)
             {
+                // ToDo: refactor resolver and validator when we support multiple configuration versions.
                 case SupportedConfigVersion.V1:
                     ConfigurationResolverV1.Resolve(services, configuration);
                     ConfigurationValidatorV1.Validate(services);

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Extensions/ConfigurationRegistrationExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Extensions/ConfigurationRegistrationExtensions.cs
@@ -3,10 +3,13 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
-using Microsoft.Health.Fhir.Synapse.Common.Configurations.Arrow;
+using Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationResolvers;
+using Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValidators;
+using Microsoft.Health.Fhir.Synapse.Common.Exceptions;
 
 namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
 {
@@ -16,29 +19,20 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Extensions
             this IServiceCollection services,
             IConfiguration configuration)
         {
-            services.Configure<FhirServerConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.FhirServerConfigurationKey).Bind(options));
-            services.Configure<JobConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.JobConfigurationKey).Bind(options));
-            services.Configure<FilterConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.FilterConfigurationKey).Bind(options));
-            services.Configure<FilterLocation>(options =>
-                configuration.GetSection(ConfigurationConstants.FilterConfigurationKey).Bind(options));
-            services.Configure<DataLakeStoreConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.DataLakeStoreConfigurationKey).Bind(options));
-            services.Configure<ArrowConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.ArrowConfigurationKey).Bind(options));
-            services.Configure<JobSchedulerConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.SchedulerConfigurationKey).Bind(options));
-            services.Configure<SchemaConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.SchemaConfigurationKey).Bind(options));
-            services.Configure<HealthCheckConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.HealthCheckConfigurationKey).Bind(options));
-            services.Configure<StorageConfiguration>(options =>
-                configuration.GetSection(ConfigurationConstants.StorageConfigurationKey).Bind(options));
+            string configVersionValue = configuration[ConfigurationConstants.ConfigVersionKey];
+            Enum.TryParse(configVersionValue, out SupportedConfigVersion configVersion);
 
-            // Validates the input configs.
-            services.ValidateConfiguration();
+            switch (configVersion)
+            {
+                case SupportedConfigVersion.V1:
+                    ConfigurationResolverV1.Resolve(services, configuration);
+                    ConfigurationValidatorV1.Validate(services);
+                    break;
+
+                default:
+                    throw new ConfigurationErrorException($"ConfigVersion '{configVersionValue}' is not supported.");
+            }
+
             return services;
         }
     }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/appsettings.json
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "configVersion": 1,
   "fhirServer": {
     "serverUrl": "",
     "version": "R4",
@@ -22,7 +23,7 @@
   "filter": {
     "enableExternalFilter": false,
     "filterImageReference": "",
-    "filterConfigurationFileName" : "",
+    "filterConfigurationFileName": "",
     "filterScope": "System",
     "groupId": "",
     "requiredTypes": "",
@@ -30,12 +31,12 @@
   },
   "arrow": {
     "readOptions": {
-        "useThreads": true,
-        "blockSize": 30485760
+      "useThreads": true,
+      "blockSize": 30485760
     },
     "writeOptions": {
-        "writeBatchSize": 100,
-        "compression": "SNAPPY"
+      "writeBatchSize": 100,
+      "compression": "SNAPPY"
     }
   },
   "schema": {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/appsettings.json
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "configVersion": 1,
   "fhirServer": {
     "serverUrl": "",
     "version": "R4",
@@ -22,7 +23,7 @@
   "filter": {
     "enableExternalFilter": false,
     "filterImageReference": "",
-    "filterConfigurationFileName" : "",
+    "filterConfigurationFileName": "",
     "filterScope": "System",
     "groupId": "",
     "requiredTypes": "",
@@ -30,12 +31,12 @@
   },
   "arrow": {
     "readOptions": {
-        "useThreads": true,
-        "blockSize": 30485760
+      "useThreads": true,
+      "blockSize": 30485760
     },
     "writeOptions": {
-        "writeBatchSize": 100,
-        "compression": "SNAPPY"
+      "writeBatchSize": 100,
+      "compression": "SNAPPY"
     }
   },
   "schema": {

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Extensions/ConfigurationRegistrationExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Extensions/ConfigurationRegistrationExtensionsTests.cs
@@ -1,0 +1,94 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Health.Fhir.Synapse.Common.Configurations;
+using Microsoft.Health.Fhir.Synapse.Common.Configurations.Arrow;
+using Microsoft.Health.Fhir.Synapse.Common.Exceptions;
+using Microsoft.Health.Fhir.Synapse.Common.Extensions;
+using Microsoft.Health.Fhir.Synapse.Common.Models.Jobs;
+using Xunit;
+
+namespace Microsoft.Health.Fhir.Synapse.Common.UnitTests.Extensions
+{
+    public class ConfigurationRegistrationExtensionsTests
+    {
+        private static readonly Dictionary<string, string> TestValidConfiguration = new Dictionary<string, string>
+        {
+            { "fhirServer:serverUrl", "https://test.fhir.azurehealthcareapis.com" },
+            { "dataLakeStore:storageUrl", "https://test.blob.core.windows.net/" },
+            { "job:jobInfoTableName", "jobinfotable" },
+            { "job:metadataTableName", "metadatatable" },
+            { "job:jobInfoQueueName", "jobinfoqueue" },
+            { "job:containerName", "fhir" },
+            { "job:queueUrl", "UseDevelopmentStorage=true" },
+            { "job:tableUrl", "UseDevelopmentStorage=true" },
+            { "job:schedulerCronExpression", "5 * * * * *" },
+            { "job:queueType", "FhirToDataLake" },
+            { "configVersion", "1" },
+        };
+
+        public static IEnumerable<object[]> GetInvalidServiceConfiguration()
+        {
+            yield return new object[] { "fhirServer:serverUrl", string.Empty, "Fhir server url can not be empty." };
+            yield return new object[] { "job:containerName", string.Empty, "Target azure container name can not be empty." };
+            yield return new object[] { "dataLakeStore:storageUrl", string.Empty, "Target azure storage url can not be empty." };
+            yield return new object[] { "fhirServer:version", "invalidVersion", "Failed to parse fhir server configuration" };
+            yield return new object[] { "job:startTime", "invalidDataTime", "Failed to parse job configuration" };
+            yield return new object[] { "filter:filterScope", "invalidScope", "Failed to parse filter configuration" };
+            yield return new object[] { "schema:schemaImageReference", 12345, "Found the schema image reference but customized schema is disable." };
+            yield return new object[] { "configVersion", -1, "ConfigVersion '-1' is not supported." };
+            yield return new object[] { "configVersion", 0, "ConfigVersion '0' is not supported." };
+            yield return new object[] { "configVersion", 2, "ConfigVersion '2' is not supported." };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInvalidServiceConfiguration))]
+        public void GivenInvalidServiceCollectionConfiguration_WhenValidate_ExceptionShouldBeThrown(string configKey, string configValue, string expectedMessageStart)
+        {
+            var config = new Dictionary<string, string>(TestValidConfiguration);
+            config[configKey] = configValue;
+
+            var builder = new ConfigurationBuilder();
+            builder.AddInMemoryCollection(config);
+            var serviceCollection = new ServiceCollection();
+
+            var exception = Assert.Throws<ConfigurationErrorException>(() => serviceCollection.AddConfiguration(builder.Build()));
+            Assert.StartsWith(expectedMessageStart, exception.Message);
+        }
+
+        [Fact]
+        public void GivenValidServiceCollectionConfiguration_WhenValidate_NoExceptionShouldBeThrown()
+        {
+            var builder = new ConfigurationBuilder();
+            builder.AddInMemoryCollection(TestValidConfiguration);
+            var config = builder.Build();
+
+            var serviceCollection = new ServiceCollection();
+            var exception = Record.Exception(() => serviceCollection.AddConfiguration(config));
+            Assert.Null(exception);
+        }
+
+        private static void RegistryConfiguration(IServiceCollection services, IConfigurationRoot configuration)
+        {
+            services.Configure<FhirServerConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.FhirServerConfigurationKey).Bind(options));
+            services.Configure<JobConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.JobConfigurationKey).Bind(options));
+            services.Configure<FilterConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.FilterConfigurationKey).Bind(options));
+            services.Configure<DataLakeStoreConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.DataLakeStoreConfigurationKey).Bind(options));
+            services.Configure<ArrowConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.ArrowConfigurationKey).Bind(options));
+            services.Configure<JobSchedulerConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.SchedulerConfigurationKey).Bind(options));
+            services.Configure<SchemaConfiguration>(options =>
+                configuration.GetSection(ConfigurationConstants.SchemaConfigurationKey).Bind(options));
+        }
+    }
+}

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Extensions/ConfigurationRegistrationExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Extensions/ConfigurationRegistrationExtensionsTests.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Health.Fhir.Synapse.Common.UnitTests.Extensions
             yield return new object[] { "configVersion", -1, "ConfigVersion '-1' is not supported." };
             yield return new object[] { "configVersion", 0, "ConfigVersion '0' is not supported." };
             yield return new object[] { "configVersion", 2, "ConfigVersion '2' is not supported." };
+            yield return new object[] { "configVersion", "1.0", "ConfigVersion '1.0' is not supported." };
+            yield return new object[] { "configVersion", "abc", "ConfigVersion 'abc' is not supported." };
         }
 
         [Theory]

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/appsettings.test.json
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/appsettings.test.json
@@ -1,4 +1,5 @@
 ﻿{
+  "configVersion": 1,
   "fhirServer": {
     "serverUrl": "http://127.0.0.1:5000",
     "authentication": "None"


### PR DESCRIPTION
Add config versioning strategy for future compatibility.
When we need to embrace new version of configurations, a common strategy should be bump the config version and add corresponding config resolver and validator if needed. By the way, we may need to have different versions for XXXConfiguration objects in case of property conflicts  in the future.
