### PR TITLE
[bugfix] The job may hang when update job progress

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Models/Jobs/Job.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Models/Jobs/Job.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Health.Fhir.Synapse.Common.Models.FhirSearch;
 using Microsoft.Health.Fhir.Synapse.Common.Models.Tasks;
@@ -23,7 +24,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Models.Jobs
             DateTimeOffset lastHeartBeat,
             IEnumerable<PatientWrapper> patients = null,
             int nextTaskIndex = 0,
-            Dictionary<string, TaskContext> runningTasks = null,
+            ConcurrentDictionary<string, TaskContext> runningTasks = null,
             Dictionary<string, int> totalResourceCounts = null,
             Dictionary<string, int> processedResourceCounts = null,
             Dictionary<string, int> skippedResourceCounts = null,
@@ -48,7 +49,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Models.Jobs
 
             // fields to record job progress
             NextTaskIndex = nextTaskIndex;
-            RunningTasks = runningTasks ?? new Dictionary<string, TaskContext>();
+            RunningTasks = runningTasks ?? new ConcurrentDictionary<string, TaskContext>();
 
             // statistical fields
             TotalResourceCounts = totalResourceCounts ?? new Dictionary<string, int>();
@@ -134,7 +135,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Models.Jobs
         /// The running tasks
         /// </summary>
         [JsonProperty("runningTasks")]
-        public Dictionary<string, TaskContext> RunningTasks { get; set; }
+        public ConcurrentDictionary<string, TaskContext> RunningTasks { get; set; }
 
         /// <summary>
         /// Total resource count (from data source) for each resource types.
@@ -167,7 +168,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Models.Jobs
             FilterInfo filterInfo,
             IEnumerable<PatientWrapper> patients = null,
             int nextTaskIndex = 0,
-            Dictionary<string, TaskContext> runningTasks = null,
+            ConcurrentDictionary<string, TaskContext> runningTasks = null,
             Dictionary<string, int> totalResourceCounts = null,
             Dictionary<string, int> processedResourceCounts = null,
             Dictionary<string, int> skippedResourceCounts = null,

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/JobProgressUpdater.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/JobProgressUpdater.cs
@@ -52,8 +52,6 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     // when the first context is consumed, its data are merged to job and it is removed from the job, so we do nothing for the second context.
                     if (_job.RunningTasks.ContainsKey(context.Id))
                     {
-                        _job.RunningTasks[context.Id] = context;
-
                         if (context.IsCompleted)
                         {
                             _job.TotalResourceCounts = _job.TotalResourceCounts.ConcatDictionaryCount(context.SearchCount);

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/JobProgressUpdater.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/JobProgressUpdater.cs
@@ -69,7 +69,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                                 }
                             }
 
-                            _job.RunningTasks.Remove(context.Id);
+                            if (!_job.RunningTasks.TryRemove(context.Id, out TaskContext retrievedTaskContext))
+                            {
+                                _logger.LogWarning($"Fail to remove task {context.Id} from job's running tasks dictionary.");
+                            }
                         }
                     }
 


### PR DESCRIPTION
This pr is to fix the bug that the job may hang when trying to update job progress.

Channel is used to update job progress when a task is completed, the completed task will be removed from the job's runningTasks, it's async and may hang as Dictionary is not thread-safe. Use `concurrencyDictionay`  for runningTasks to fix this issue.