### PR TITLE
Remove _sort search parameter

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiConstants.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiConstants.cs
@@ -32,11 +32,6 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
         public const string ContinuationKey = "ct";
 
         /// <summary>
-        /// Sort search parameter.
-        /// </summary>
-        public const string SortKey = "_sort";
-
-        /// <summary>
         /// Type search parameter.
         /// </summary>
         public const string TypeKey = "_type";

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
 
             uri = uri.AddQueryString(fhirApiOptions.QueryParameters);
 
-            // add shared parameters _count & sort
+            // add shared parameters _count
             var queryParameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.PageCountKey, FhirApiConstants.PageCount.ToString()),

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
@@ -144,7 +144,6 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
             var queryParameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.PageCountKey, FhirApiConstants.PageCount.ToString()),
-                new (FhirApiConstants.SortKey, FhirApiConstants.LastUpdatedKey),
             };
 
             return uri.AddQueryString(queryParameters);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/FhirApiDataClientTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/FhirApiDataClientTests.cs
@@ -233,25 +233,25 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
             var comparer = StringComparer.OrdinalIgnoreCase;
             var requestMap = new Dictionary<string, HttpResponseMessage>(comparer);
             requestMap.Add(
-                $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&_count=1000&_sort=_lastUpdated",
+                $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&_count=1000",
                 CreateResponseMessage(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1)));
             requestMap.Add(
-                $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&ct=Y29udGludWF0aW9udG9rZW4%3d&_count=1000&_sort=_lastUpdated",
+                $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&ct=Y29udGludWF0aW9udG9rZW4%3d&_count=1000",
                 CreateResponseMessage(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile2)));
             requestMap.Add(
-                $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&ct=invalidresponsetest&_count=1000&_sort=_lastUpdated",
+                $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&ct=invalidresponsetest&_count=1000",
                 CreateResponseMessage(TestDataProvider.GetBundleFromFile(TestDataConstants.InvalidResponseFile)));
             requestMap.Add(
-                $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&ct=invalidbundletest&_count=1000&_sort=_lastUpdated",
+                $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&ct=invalidbundletest&_count=1000",
                 CreateResponseMessage(TestDataProvider.GetBundleFromFile(TestDataConstants.InvalidBundleFile)));
             requestMap.Add(
-                $"{fhirServerUrl.TrimEnd('/')}/Patient?_count=1000&_sort=_lastUpdated",
+                $"{fhirServerUrl.TrimEnd('/')}/Patient?_count=1000",
                 CreateResponseMessage(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1)));
             requestMap.Add(
-                $"{fhirServerUrl.TrimEnd('/')}/MedicationRequest?_id=3123&_count=1000&_sort=_lastUpdated",
+                $"{fhirServerUrl.TrimEnd('/')}/MedicationRequest?_id=3123&_count=1000",
                 CreateResponseMessage(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1)));
             requestMap.Add(
-                $"{fhirServerUrl.TrimEnd('/')}/Patient/347/*?_lastUpdated=ge2021-08-01T12%3a00%3a00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3a40%3a59%2b08%3a00&_count=1000&_sort=_lastUpdated",
+                $"{fhirServerUrl.TrimEnd('/')}/Patient/347/*?_lastUpdated=ge2021-08-01T12%3a00%3a00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3a40%3a59%2b08%3a00&_count=1000",
                 CreateResponseMessage(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1)));
             requestMap.Add(
                 $"{fhirServerUrl.TrimEnd('/')}/metadata",

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 CheckJobStatus(jobInfo, "GroupScope_OnePatient_All.json");
 
                 // Check result files
-                Assert.Equal(20, await GetResultFileCount(_blobContainerClient, "result"));
+                Assert.Equal(16, await GetResultFileCount(_blobContainerClient, "result"));
 
                 var patientVersions =
                     await _metadataStore.GetPatientVersionsAsync(QueueTypeByte, CancellationToken.None);


### PR DESCRIPTION
`_sort` will bring latency issue when querying cosmos db backed FHIR server with large volumn of data. And removing sort will not cause changes to the data lake result.