### PR TITLE
Refine SchemaManagement Project 

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/FhirParquetSchemaManager.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/FhirParquetSchemaManager.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet
 
         public List<string> GetSchemaTypes(string resourceType)
         {
-            if (!SchemaTypesMap.ContainsKey(resourceType))
+            if (string.IsNullOrWhiteSpace(resourceType) || !SchemaTypesMap.ContainsKey(resourceType))
             {
                 _logger.LogInformation($"Schema types for {resourceType} is empty.");
                 return new List<string>();
@@ -86,7 +86,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet
 
         public FhirParquetSchemaNode GetSchema(string schemaType)
         {
-            if (!ResourceSchemaNodesMap.ContainsKey(schemaType))
+            if (string.IsNullOrWhiteSpace(schemaType) || !ResourceSchemaNodesMap.ContainsKey(schemaType))
             {
                 _logger.LogInformation($"Schema for schema type {schemaType} is not supported.");
                 return null;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/AcrCustomizedSchemaProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/AcrCustomizedSchemaProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EnsureThat;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Liquid.Converter.Models.Json;
@@ -32,9 +33,11 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
             IDiagnosticLogger diagnosticLogger,
             ILogger<AcrCustomizedSchemaProvider> logger)
         {
-            _diagnosticLogger = diagnosticLogger;
-            _logger = logger;
-            _containerRegistryTemplateProvider = containerRegistryTemplateProvider;
+            EnsureArg.IsNotNull(schemaConfiguration, nameof(schemaConfiguration));
+
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+            _diagnosticLogger = EnsureArg.IsNotNull(diagnosticLogger, nameof(diagnosticLogger));
+            _containerRegistryTemplateProvider = EnsureArg.IsNotNull(containerRegistryTemplateProvider, nameof(containerRegistryTemplateProvider)) ;
             _schemaImageReference = schemaConfiguration.Value.SchemaImageReference;
         }
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/JsonSchemaParser.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/JsonSchemaParser.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using EnsureThat;
 using Microsoft.Health.Fhir.Synapse.SchemaManagement.Exceptions;
 using NJsonSchema;
 
@@ -20,6 +21,9 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
         /// <returns>A FhirParquetSchemaNode instance.</returns>
         public static FhirParquetSchemaNode ParseJSchema(string resourceType, JsonSchema jsonSchema)
         {
+            EnsureArg.IsNotNullOrWhiteSpace(resourceType, nameof(resourceType));
+            EnsureArg.IsNotNull(jsonSchema, nameof(jsonSchema));
+
             if (jsonSchema.Type == JsonObjectType.None || jsonSchema.Type == JsonObjectType.Null)
             {
                 throw new GenerateFhirParquetSchemaNodeException(string.Format("The \"{0}\" customized schema have no \"type\" keyword or \"type\" is null.", resourceType));

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/LocalDefaultSchemaProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/LocalDefaultSchemaProvider.cs
@@ -36,12 +36,10 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
             ILogger<LocalDefaultSchemaProvider> logger)
         {
             EnsureArg.IsNotNull(fhirServerConfiguration, nameof(fhirServerConfiguration));
-            EnsureArg.IsNotNull(logger, nameof(logger));
-            EnsureArg.IsNotNull(diagnosticLogger, nameof(diagnosticLogger));
 
-            _fhirVersion = fhirServerConfiguration.Value.Version;
-            _diagnosticLogger = diagnosticLogger;
-            _logger = logger;
+            _fhirVersion = EnsureArg.EnumIsDefined(fhirServerConfiguration.Value.Version, nameof(fhirServerConfiguration.Value.Version));
+            _diagnosticLogger = EnsureArg.IsNotNull(diagnosticLogger, nameof(diagnosticLogger));
+            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
         }
 
         public Task<Dictionary<string, FhirParquetSchemaNode>> GetSchemasAsync(CancellationToken cancellationToken = default)

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/FhirParquetSchemaManagerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/FhirParquetSchemaManagerTests.cs
@@ -3,10 +3,10 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
-using Microsoft.Health.Fhir.Synapse.Common.Logging;
 using Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet;
 using Xunit;
 
@@ -31,6 +31,22 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
             _testParquetSchemaManagerWithCustomizedSchema = new FhirParquetSchemaManager(schemaConfigurationOptionWithCustomizedSchema, TestUtils.TestParquetSchemaProviderDelegate, NullLogger<FhirParquetSchemaManager>.Instance);
         }
 
+        [Fact]
+        public void GivenNullInputParameters_WhenInitialize_ExceptionShouldBeThrown()
+        {
+            var schemaConfigurationOption = Options.Create(new SchemaConfiguration());
+            var loggerInstance = NullLogger<FhirParquetSchemaManager>.Instance;
+
+            Assert.Throws<ArgumentNullException>(
+                () => new FhirParquetSchemaManager(null, TestUtils.TestParquetSchemaProviderDelegate, loggerInstance));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new FhirParquetSchemaManager(schemaConfigurationOption, null, loggerInstance));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new FhirParquetSchemaManager(schemaConfigurationOption, TestUtils.TestParquetSchemaProviderDelegate, null));
+        }
+
         [InlineData("Patient", 24)]
         [InlineData("Observation", 32)]
         [InlineData("Encounter", 31)]
@@ -45,12 +61,14 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
             Assert.Equal(propertyCount, result.SubNodes.Count);
         }
 
-        [Fact]
-        public static void GivenInvalidSchemaType_WhenGetSchema_NullShouldBeReturned()
+        [InlineData("NoneExistSchemaType")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        [Theory]
+        public static void GivenInvalidSchemaType_WhenGetSchema_NullShouldBeReturned(string invalidSchemaType)
         {
-            var schemaType = "InvalidSchemaType";
-
-            var result = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchema(schemaType);
+            var result = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchema(invalidSchemaType);
             Assert.Null(result);
         }
 
@@ -91,12 +109,14 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
             Assert.Contains<string>("Patient_Customized", schemaTypes);
         }
 
-        [Fact]
-        public static void GivenInvalidResourceType_WhenGetSchemaTypes_EmptyResultShouldBeReturned()
+        [InlineData("InvalidResourceType")]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        [Theory]
+        public static void GivenInvalidResourceType_WhenGetSchemaTypes_EmptyResultShouldBeReturned(string invalidResourceType)
         {
-            var resourceType = "InvalidResourceType";
-
-            var schemaTypes = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchemaTypes(resourceType);
+            var schemaTypes = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchemaTypes(invalidResourceType);
             Assert.Empty(schemaTypes);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/AcrCustomizedSchemaProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/AcrCustomizedSchemaProviderTests.cs
@@ -3,11 +3,14 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.IO;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
 using Microsoft.Health.Fhir.Synapse.Common.Logging;
+using Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry;
 using Microsoft.Health.Fhir.Synapse.SchemaManagement.Exceptions;
 using Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider;
 using NJsonSchema;
@@ -17,27 +20,45 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
 {
     public class AcrCustomizedSchemaProviderTests
     {
-        private static readonly SchemaConfiguration _schemaConfigurationWithCustomizedSchema;
+        private static readonly IContainerRegistryTemplateProvider _mockContainerRegistryTemplateProvider;
+        private static readonly IOptions<SchemaConfiguration> _schemaConfigurationWithCustomizedSchemaOption;
+        private static readonly ILogger<AcrCustomizedSchemaProvider> _nullLogger;
+        private static readonly IDiagnosticLogger _diagnosticLogger;
 
         static AcrCustomizedSchemaProviderTests()
         {
-            _schemaConfigurationWithCustomizedSchema = new SchemaConfiguration()
+            _diagnosticLogger = new DiagnosticLogger();
+            _nullLogger = NullLogger<AcrCustomizedSchemaProvider>.Instance;
+            _schemaConfigurationWithCustomizedSchemaOption = Options.Create(new SchemaConfiguration()
             {
                 EnableCustomizedSchema = true,
                 SchemaImageReference = TestUtils.MockSchemaImageReference,
-            };
+            });
+
+            var testSchemaTemplateCollections = TestUtils.GetSchemaTemplateCollections("Schema/Patient.schema.json", File.ReadAllBytes(TestUtils.TestJsonSchemaFilePath));
+            _mockContainerRegistryTemplateProvider = TestUtils.GetMockAcrTemplateProvider(testSchemaTemplateCollections);
+        }
+
+        [Fact]
+        public void GivenNullInputParameters_WhenInitialize_ExceptionShouldBeThrown()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new AcrCustomizedSchemaProvider(null, _schemaConfigurationWithCustomizedSchemaOption, _diagnosticLogger, _nullLogger));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new AcrCustomizedSchemaProvider(_mockContainerRegistryTemplateProvider, null, _diagnosticLogger, _nullLogger));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new AcrCustomizedSchemaProvider(_mockContainerRegistryTemplateProvider, _schemaConfigurationWithCustomizedSchemaOption, null, _nullLogger));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new AcrCustomizedSchemaProvider(_mockContainerRegistryTemplateProvider, _schemaConfigurationWithCustomizedSchemaOption, _diagnosticLogger, null));
         }
 
         [Fact]
         public static async void GivenImageReference_WhenGetSchemaWithMockTemplateProvider_CorrectResultShouldBeReturned()
         {
-            var testSchemaTemplateCollections = TestUtils.GetSchemaTemplateCollections("Schema/Patient.schema.json", File.ReadAllBytes(TestUtils.TestJsonSchemaFilePath));
-
-            var schemaProvider = new AcrCustomizedSchemaProvider(
-                TestUtils.GetMockAcrTemplateProvider(testSchemaTemplateCollections),
-                Options.Create(_schemaConfigurationWithCustomizedSchema),
-                new DiagnosticLogger(),
-                NullLogger<AcrCustomizedSchemaProvider>.Instance);
+            var schemaProvider = new AcrCustomizedSchemaProvider(_mockContainerRegistryTemplateProvider, _schemaConfigurationWithCustomizedSchemaOption, _diagnosticLogger, _nullLogger);
 
             var schemaCollections = await schemaProvider.GetSchemasAsync();
             var expectedSchemaNode = JsonSchemaParser.ParseJSchema("Patient", JsonSchema.FromJsonAsync(File.ReadAllText(TestUtils.TestJsonSchemaFilePath)).GetAwaiter().GetResult());
@@ -52,9 +73,26 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
             var testSchemaTemplateCollections = TestUtils.GetSchemaTemplateCollections(schemaKey, File.ReadAllBytes(TestUtils.TestJsonSchemaFilePath));
             var schemaProvider = new AcrCustomizedSchemaProvider(
                 TestUtils.GetMockAcrTemplateProvider(testSchemaTemplateCollections),
-                Options.Create(_schemaConfigurationWithCustomizedSchema),
-                new DiagnosticLogger(),
-                NullLogger<AcrCustomizedSchemaProvider>.Instance);
+                _schemaConfigurationWithCustomizedSchemaOption,
+                _diagnosticLogger,
+                _nullLogger);
+
+            await Assert.ThrowsAsync<ContainerRegistrySchemaException>(() => schemaProvider.GetSchemasAsync());
+        }
+
+        [Fact]
+        public static async void GivenNullImageReference_WhenGetSchemaWithInvalidTemplateProvider_ExceptionResultShouldBeThrown()
+        {
+            var schemaConfigurationWithCustomizedSchemaOption = Options.Create(new SchemaConfiguration()
+            {
+                SchemaImageReference = null,
+            });
+
+            var schemaProvider = new AcrCustomizedSchemaProvider(
+                _mockContainerRegistryTemplateProvider,
+                schemaConfigurationWithCustomizedSchemaOption,
+                _diagnosticLogger,
+                _nullLogger);
 
             await Assert.ThrowsAsync<ContainerRegistrySchemaException>(() => schemaProvider.GetSchemasAsync());
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/LocalDefaultSchemaProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/LocalDefaultSchemaProviderTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
@@ -14,14 +15,31 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
 {
     public class LocalDefaultSchemaProviderTests
     {
-        private static readonly LocalDefaultSchemaProvider _testLocalDefaultSchemaProvider;
+        private static readonly LocalDefaultSchemaProvider _testLocalDefaultR4SchemaProvider;
 
         static LocalDefaultSchemaProviderTests()
         {
-            _testLocalDefaultSchemaProvider = new LocalDefaultSchemaProvider(
+            _testLocalDefaultR4SchemaProvider = new LocalDefaultSchemaProvider(
                 Options.Create(new FhirServerConfiguration()),
                 new DiagnosticLogger(),
                 NullLogger<LocalDefaultSchemaProvider>.Instance);
+        }
+
+        [Fact]
+        public void GivenNullInputParameters_WhenInitialize_ExceptionShouldBeThrown()
+        {
+            var fhirServerConfigurationOption = Options.Create(new FhirServerConfiguration());
+            var diagnosticLogger = new DiagnosticLogger();
+            var loggerInstance = NullLogger<LocalDefaultSchemaProvider>.Instance;
+
+            Assert.Throws<ArgumentNullException>(
+                () => new LocalDefaultSchemaProvider(null, diagnosticLogger, loggerInstance));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new LocalDefaultSchemaProvider(fhirServerConfigurationOption, null, loggerInstance));
+
+            Assert.Throws<ArgumentNullException>(
+                () => new LocalDefaultSchemaProvider(fhirServerConfigurationOption, diagnosticLogger, null));
         }
 
         [InlineData("Patient", 24)]
@@ -29,15 +47,36 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
         [InlineData("Encounter", 31)]
         [InlineData("Claim", 35)]
         [Theory]
-        public static async void GivenSchemaDirectory_WhenGetSchema_CorrectResultShouldBeReturned(string schemaType, int propertyCount)
+        public static async void GivenSchemaDirectory_WhenGetR4Schema_CorrectResultShouldBeReturned(string schemaType, int propertyCount)
         {
-            var defaultSchemas = await _testLocalDefaultSchemaProvider.GetSchemasAsync();
+            var defaultR4Schemas = await _testLocalDefaultR4SchemaProvider.GetSchemasAsync();
 
-            Assert.Equal(145, defaultSchemas.Count);
+            Assert.Equal(145, defaultR4Schemas.Count);
 
-            Assert.Equal(schemaType, defaultSchemas[schemaType].Name);
-            Assert.False(defaultSchemas[schemaType].IsLeaf);
-            Assert.Equal(propertyCount, defaultSchemas[schemaType].SubNodes.Count);
+            Assert.Equal(schemaType, defaultR4Schemas[schemaType].Name);
+            Assert.False(defaultR4Schemas[schemaType].IsLeaf);
+            Assert.Equal(propertyCount, defaultR4Schemas[schemaType].SubNodes.Count);
+        }
+
+        [InlineData("Patient", 24)]
+        [InlineData("Observation", 33)]
+        [InlineData("Encounter", 33)]
+        [InlineData("Citation", 38)]
+        [Theory]
+        public static async void GivenSchemaDirectory_WhenGetR5Schema_CorrectResultShouldBeReturned(string schemaType, int propertyCount)
+        {
+            var schemaProvider = new LocalDefaultSchemaProvider(
+                Options.Create(new FhirServerConfiguration() { Version = Common.FhirVersion.R5 }),
+                new DiagnosticLogger(),
+                NullLogger<LocalDefaultSchemaProvider>.Instance);
+
+            var defaultR5Schemas = await schemaProvider.GetSchemasAsync();
+
+            Assert.Equal(151, defaultR5Schemas.Count);
+
+            Assert.Equal(schemaType, defaultR5Schemas[schemaType].Name);
+            Assert.False(defaultR5Schemas[schemaType].IsLeaf);
+            Assert.Equal(propertyCount, defaultR5Schemas[schemaType].SubNodes.Count);
         }
     }
 }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestData/CustomizedSchema/SchemaWithInvalidPropertyType.schema.json
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestData/CustomizedSchema/SchemaWithInvalidPropertyType.schema.json
@@ -1,8 +1,0 @@
-﻿{
-  "title": "Patient customized schema",
-  "type": "object",
-  "properties": {
-    "resourceType": { "type": "array" },
-    "id": { "type": "string" }
-  }
-}

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestData/CustomizedSchema/SchemaWithInvalidType.schema.json
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestData/CustomizedSchema/SchemaWithInvalidType.schema.json
@@ -1,8 +1,0 @@
-﻿{
-  "title": "Patient customized schema",
-  "type": "array",
-  "properties": {
-    "resourceType": { "type": "string" },
-    "id": { "type": "string" }
-  }
-}

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestData/CustomizedSchema/SchemaWithoutPropertyType.schema.json
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestData/CustomizedSchema/SchemaWithoutPropertyType.schema.json
@@ -1,8 +1,0 @@
-﻿{
-  "title": "Patient customized schema",
-  "type": "object",
-  "properties": {
-    "resourceType": { "description": "Miss type keyword" },
-    "id": { "type": "string" }
-  }
-}

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestData/CustomizedSchema/SchemaWithoutType.schema.json
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestData/CustomizedSchema/SchemaWithoutType.schema.json
@@ -1,7 +1,0 @@
-﻿{
-  "title": "Patient customized schema",
-  "properties": {
-    "resourceType": { "type": "string" },
-    "id": { "type": "string" }
-  }
-}


### PR DESCRIPTION
1. Add tests.
2. Handle more corner cases, including null, empty or invalid inputs, or invalid schema content.