### PR TITLE
Build warning fix and code style refines

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Authentication/DefaultTokenCredentialProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Authentication/DefaultTokenCredentialProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Authentication
 
         public TokenCredential GetCredential(TokenCredentialTypes type)
         {
-            var credential = new DefaultAzureCredential();
+            DefaultAzureCredential credential = new DefaultAzureCredential();
 
             _logger.LogInformation($"Get {type} token credential successfully.");
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/Arrow/ArrowWriteOptionsConfiguration.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/Arrow/ArrowWriteOptionsConfiguration.cs
@@ -12,7 +12,14 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.Arrow
     /// </summary>
     public enum CompressionOptions
     {
+        /// <summary>
+        /// UNCOMPRESSED
+        /// </summary>
         UNCOMPRESSED,
+
+        /// <summary>
+        /// SNAPPY
+        /// </summary>
         SNAPPY,
     }
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/AuthenticationType.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/AuthenticationType.cs
@@ -7,10 +7,14 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations
 {
     public enum AuthenticationType
     {
-        // Access resource with managed identity
+        /// <summary>
+        /// Access resource with managed identity
+        /// </summary>
         ManagedIdentity,
 
-        // Access resource with no authentication
+        /// <summary>
+        /// Access resource with no authentication
+        /// </summary>
         None,
     }
 }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ConfigurationValidatorV1.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ConfigurationValidatorV1.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
 
             if (string.IsNullOrWhiteSpace(fhirServerConfiguration.ServerUrl))
             {
-                throw new ConfigurationErrorException($"Fhir server url can not be empty.");
+                throw new ConfigurationErrorException("Fhir server url can not be empty.");
             }
 
             if (!ConfigurationConstants.SupportedFhirVersions.Contains(fhirServerConfiguration.Version))
@@ -66,22 +66,22 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
 
             if (string.IsNullOrWhiteSpace(jobConfiguration.TableUrl))
             {
-                throw new ConfigurationErrorException($"Table Url can not be empty.");
+                throw new ConfigurationErrorException("Table Url can not be empty.");
             }
 
             if (string.IsNullOrWhiteSpace(jobConfiguration.QueueUrl))
             {
-                throw new ConfigurationErrorException($"Queue Url can not be empty.");
+                throw new ConfigurationErrorException("Queue Url can not be empty.");
             }
 
             if (string.IsNullOrWhiteSpace(jobConfiguration.SchedulerCronExpression))
             {
-                throw new ConfigurationErrorException($"Scheduler crontab expression can not be empty.");
+                throw new ConfigurationErrorException("Scheduler crontab expression can not be empty.");
             }
 
             if (string.IsNullOrWhiteSpace(jobConfiguration.ContainerName))
             {
-                throw new ConfigurationErrorException($"Target azure container name can not be empty.");
+                throw new ConfigurationErrorException("Target azure container name can not be empty.");
             }
 
             if (jobConfiguration.MaxRunningJobCount < 1)
@@ -122,7 +122,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
             {
                 if (string.IsNullOrWhiteSpace(filterLocation.FilterImageReference))
                 {
-                    throw new ConfigurationErrorException($"Filter image reference can not be empty when external filter configuration is enable.");
+                    throw new ConfigurationErrorException("Filter image reference can not be empty when external filter configuration is enable.");
                 }
 
                 ValidateUtility.ValidateImageReference(filterLocation.FilterImageReference);
@@ -145,14 +145,14 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
                 ValidateUtility.ValidateFilterConfiguration(filterConfiguration);
             }
 
-            var storeConfiguration = services
+            DataLakeStoreConfiguration storeConfiguration = services
                 .BuildServiceProvider()
                 .GetRequiredService<IOptions<DataLakeStoreConfiguration>>()
                 .Value;
 
             if (string.IsNullOrWhiteSpace(storeConfiguration.StorageUrl))
             {
-                throw new ConfigurationErrorException($"Target azure storage url can not be empty.");
+                throw new ConfigurationErrorException("Target azure storage url can not be empty.");
             }
 
             SchemaConfiguration schemaConfiguration;
@@ -172,7 +172,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
             {
                 if (string.IsNullOrWhiteSpace(schemaConfiguration.SchemaImageReference))
                 {
-                    throw new ConfigurationErrorException($"Customized schema image reference can not be empty when customized schema is enable.");
+                    throw new ConfigurationErrorException("Customized schema image reference can not be empty when customized schema is enable.");
                 }
                 else
                 {
@@ -183,7 +183,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
             {
                 if (!string.IsNullOrWhiteSpace(schemaConfiguration.SchemaImageReference))
                 {
-                    throw new ConfigurationErrorException($"Found the schema image reference but customized schema is disable.");
+                    throw new ConfigurationErrorException("Found the schema image reference but customized schema is disable.");
                 }
             }
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ValidateUtility.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ValidateUtility.cs
@@ -63,8 +63,8 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
         /// Image reference pattern: <registry>/<name>@<digest> or <registry>/<name>:<tag>
         /// E.g. testacr.azurecr.io/templatetest@sha256:412ea84f1bb1a9d98345efb7b427ba89616ec29ac332d543eff9a2161ca12a58
         /// </summary>
-        /// <param name="imageReference">Image reference.</param>
-        /// <exception cref="ConfigurationErrorException">Throw ConfigurationErrorException if imageReference is invalid</exception>
+        /// <param name="imageReference">Image reference</param>
+        /// <exception cref="ConfigurationErrorException">Throw ConfigurationErrorException if imageReference is invalid.</exception>
         public static void ValidateImageReference(string imageReference)
         {
             int registryDelimiterPosition = imageReference.IndexOf(ConfigurationConstants.ImageRegistryDelimiter, StringComparison.InvariantCultureIgnoreCase);

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ValidateUtility.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/ConfigurationValidators/ValidateUtility.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
         /// <exception cref="ConfigurationErrorException">Throw ConfigurationErrorException if imageReference is invalid</exception>
         public static void ValidateImageReference(string imageReference)
         {
-            var registryDelimiterPosition = imageReference.IndexOf(ConfigurationConstants.ImageRegistryDelimiter, StringComparison.InvariantCultureIgnoreCase);
+            int registryDelimiterPosition = imageReference.IndexOf(ConfigurationConstants.ImageRegistryDelimiter, StringComparison.InvariantCultureIgnoreCase);
             if (registryDelimiterPosition <= 0 || registryDelimiterPosition == imageReference.Length - 1)
             {
                 throw new ConfigurationErrorException("Customized schema image format is invalid: registry server is missing.");
@@ -101,7 +101,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValid
 
         private static Tuple<string, string> ParseImageMeta(string input, char delimiter)
         {
-            var index = input.IndexOf(delimiter, StringComparison.InvariantCultureIgnoreCase);
+            int index = input.IndexOf(delimiter, StringComparison.InvariantCultureIgnoreCase);
             return new Tuple<string, string>(input[0..index], input[(index + 1) ..]);
         }
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/FhirVersion.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/FhirVersion.cs
@@ -10,10 +10,19 @@ namespace Microsoft.Health.Fhir.Synapse.Common
     /// </summary>
     public enum FhirVersion
     {
+        /// <summary>
+        /// R5
+        /// </summary>
         R5,
+
+        /// <summary>
+        /// R4
+        /// </summary>
         R4,
 
-        // Stu3 is not supported.
+        /// <summary>
+        /// Stu3 is not supported.
+        /// </summary>
         Stu3,
     }
 }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/ContainerRegistryFilterProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/ContainerRegistryFilterProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             try
             {
                 AcrClient client = new AcrClient(imageInfo.Registry, accessToken);
-                var filterConfigurationProvider = new OciArtifactProvider(imageInfo, client);
+                OciArtifactProvider filterConfigurationProvider = new OciArtifactProvider(imageInfo, client);
                 ArtifactImage acrImage = await Policy
                   .Handle<TemplateManagementException>()
                   .WaitAndRetryAsync(
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                         throw new ContainerRegistryFilterException(message);
                     }
 
-                    using var blobStream = new MemoryStream(acrImage.Blobs[i].Content);
+                    using MemoryStream blobStream = new MemoryStream(acrImage.Blobs[i].Content);
                     Dictionary<string, byte[]> blobsDict = StreamUtility.DecompressFromTarGz(blobStream);
                     if (!blobsDict.Keys.Contains(ConfigName))
                     {
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                             throw new ContainerRegistryFilterException(message);
                         }
 
-                        using var config = new MemoryStream(blobsDict[ConfigName]);
+                        using MemoryStream config = new MemoryStream(blobsDict[ConfigName]);
                         config.Position = 0;
                         using (StreamReader reader = new StreamReader(config))
                         {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/ContainerRegistryFilterProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/ContainerRegistryFilterProvider.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -30,7 +31,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
         private readonly string _imageReference;
         private readonly IContainerRegistryTokenProvider _containerRegistryTokenProvider;
         private readonly ILogger<ContainerRegistryFilterProvider> _logger;
-        private const string _configName = "filterConfiguration.json";
+        private const string ConfigName = "filterConfiguration.json";
         private readonly IDiagnosticLogger _diagnosticLogger;
 
         public ContainerRegistryFilterProvider(
@@ -56,27 +57,27 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             }
             catch (ImageReferenceException ex)
             {
-                var message = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: Failed to parse filter image reference {0}.", _imageReference);
+                string message = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: Failed to parse filter image reference {0}.", _imageReference);
                 _diagnosticLogger.LogError(message);
                 _logger.LogInformation(ex, message);
                 throw new ContainerRegistryFilterException(message, ex);
             }
             catch (Exception ex)
             {
-                var message = string.Format("Failed to fetch filter configuration from image reference {_imageReference}. Reason: Unhandled exception while parsing image reference {_imageReference}.", _imageReference);
+                string message = string.Format("Failed to fetch filter configuration from image reference {_imageReference}. Reason: Unhandled exception while parsing image reference {_imageReference}.", _imageReference);
 
                 _diagnosticLogger.LogError(message);
                 _logger.LogError(ex, message);
                 throw;
             }
 
-            var accessToken = await _containerRegistryTokenProvider.GetTokenAsync(imageInfo.Registry, cancellationToken);
+            string accessToken = await _containerRegistryTokenProvider.GetTokenAsync(imageInfo.Registry, cancellationToken);
 
             try
             {
                 AcrClient client = new AcrClient(imageInfo.Registry, accessToken);
                 var filterConfigurationProvider = new OciArtifactProvider(imageInfo, client);
-                var acrImage = await Policy
+                ArtifactImage acrImage = await Policy
                   .Handle<TemplateManagementException>()
                   .WaitAndRetryAsync(
                     3,
@@ -87,12 +88,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                     })
                   .ExecuteAsync(() => filterConfigurationProvider.GetOciArtifactAsync(cancellationToken));
 
-                var blobsSize = acrImage.Blobs.Count;
-                for (var i = blobsSize - 1; i >= 0; i--)
+                int blobsSize = acrImage.Blobs.Count;
+                for (int i = blobsSize - 1; i >= 0; i--)
                 {
                     if (CheckConfigurationCollectionIsTooLarge(acrImage.Blobs[i].Content.LongLength))
                     {
-                        var message = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: Configuration collection is too large.", _imageReference);
+                        string message = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: Configuration collection is too large.", _imageReference);
 
                         _diagnosticLogger.LogError(message);
                         _logger.LogInformation(message);
@@ -100,23 +101,23 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                     }
 
                     using var blobStream = new MemoryStream(acrImage.Blobs[i].Content);
-                    var blobsDict = StreamUtility.DecompressFromTarGz(blobStream);
-                    if (!blobsDict.Keys.Contains(_configName))
+                    Dictionary<string, byte[]> blobsDict = StreamUtility.DecompressFromTarGz(blobStream);
+                    if (!blobsDict.Keys.Contains(ConfigName))
                     {
                         continue;
                     }
                     else
                     {
-                        if (CheckConfigurationIsTooLarge(blobsDict[_configName].LongLength))
+                        if (CheckConfigurationIsTooLarge(blobsDict[ConfigName].LongLength))
                         {
-                            var message = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: Configuration file is too large.", _imageReference);
+                            string message = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: Configuration file is too large.", _imageReference);
 
                             _diagnosticLogger.LogError(message);
                             _logger.LogInformation(message);
                             throw new ContainerRegistryFilterException(message);
                         }
 
-                        using var config = new MemoryStream(blobsDict[_configName]);
+                        using var config = new MemoryStream(blobsDict[ConfigName]);
                         config.Position = 0;
                         using (StreamReader reader = new StreamReader(config))
                         {
@@ -127,7 +128,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                             }
                             catch (Exception ex)
                             {
-                                var message = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: Invalid filter format.", _imageReference);
+                                string message = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: Invalid filter format.", _imageReference);
 
                                 _diagnosticLogger.LogError(message);
                                 _logger.LogInformation(ex, message);
@@ -137,7 +138,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                     }
                 }
 
-                var failedMessage = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: {1} not found.", _imageReference, _configName);
+                string failedMessage = string.Format("Failed to fetch filter configuration from image reference {0}. Reason: {1} not found.", _imageReference, ConfigName);
 
                 _diagnosticLogger.LogError(failedMessage);
                 _logger.LogInformation(failedMessage);
@@ -145,7 +146,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             }
             catch (ContainerRegistryAuthenticationException authEx)
             {
-                var message = string.Format("Failed to access container registry: {0}. Authentication failed.", _imageReference);
+                string message = string.Format("Failed to access container registry: {0}. Authentication failed.", _imageReference);
 
                 _diagnosticLogger.LogError(message);
                 _logger.LogInformation(authEx, message);
@@ -153,7 +154,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             }
             catch (TemplateManagementException ex)
             {
-                var message = string.Format("Failed to fetch filter configuration from image reference {0}.", _imageReference);
+                string message = string.Format("Failed to fetch filter configuration from image reference {0}.", _imageReference);
 
                 _diagnosticLogger.LogError(message);
                 _logger.LogInformation(ex, message);
@@ -165,7 +166,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             }
             catch (Exception ex)
             {
-                var message = string.Format("Unhandled exception while fetching filter configuration from image reference {0}.", _imageReference);
+                string message = string.Format("Unhandled exception while fetching filter configuration from image reference {0}.", _imageReference);
 
                 _diagnosticLogger.LogError(message);
                 _logger.LogError(ex, message);

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/FilterManager.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/FilterManager.cs
@@ -83,20 +83,20 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             string typeString,
             string filterString)
         {
-            var requiredTypes = ParseType(filterScope, typeString).ToHashSet();
-            var typeFilters = ParseTypeFilter(filterString).ToList();
+            HashSet<string> requiredTypes = ParseType(filterScope, typeString).ToHashSet();
+            List<TypeFilter> typeFilters = ParseTypeFilter(filterString).ToList();
 
             ValidateTypeFilters(requiredTypes, typeFilters);
 
             // Generate base type filters for the types without typeFilters,
             // so dataClient can handle all the cases with a unify interface.
-            var filteredTypes = new HashSet<string>();
-            foreach (var filter in typeFilters)
+            HashSet<string> filteredTypes = new HashSet<string>();
+            foreach (TypeFilter filter in typeFilters)
             {
                 filteredTypes.Add(filter.ResourceType);
             }
 
-            var nonFilterTypes = requiredTypes.Where(x => !filteredTypes.Contains(x)).ToList();
+            List<string> nonFilterTypes = requiredTypes.Where(x => !filteredTypes.Contains(x)).ToList();
 
             if (nonFilterTypes.Any())
             {
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
         /// <returns>a list of resource type.</returns>
         private IEnumerable<string> ParseType(FilterScope filterScope, string typeString)
         {
-            var supportedResourceTypes = filterScope switch
+            HashSet<string> supportedResourceTypes = filterScope switch
             {
                 FilterScope.System => _fhirSpecificationProvider.GetAllResourceTypes().ToHashSet(),
                 FilterScope.Group => _fhirSpecificationProvider.GetCompartmentResourceTypes(FhirConstants.PatientResource).ToHashSet(),
@@ -155,10 +155,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             }
 
             // TODO: trim space for each type?
-            var types = typeString.Split(',').ToHashSet();
+            HashSet<string> types = typeString.Split(',').ToHashSet();
 
             // validate if invalid Fhir resource types
-            var invalidFhirResourceTypes =
+            List<string> invalidFhirResourceTypes =
                 types.Where(type => !_fhirSpecificationProvider.IsValidFhirResourceType(type)).ToList();
             if (invalidFhirResourceTypes.Any())
             {
@@ -169,7 +169,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             }
 
             // validate if unsupported resource types
-            var unsupportedTypes = types.Where(type => !supportedResourceTypes.Contains(type)).ToList();
+            List<string> unsupportedTypes = types.Where(type => !supportedResourceTypes.Contains(type)).ToList();
             if (unsupportedTypes.Any())
             {
                 _diagnosticLogger.LogError($"The required resource types \"{string.Join(',', unsupportedTypes)}\" aren't supported for scope {filterScope}.");
@@ -188,7 +188,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
         /// <returns>A list of <see cref="TypeFilter"/></returns>
         private IEnumerable<TypeFilter> ParseTypeFilter(string filterString)
         {
-            var filters = new List<TypeFilter>();
+            List<TypeFilter> filters = new List<TypeFilter>();
 
             if (string.IsNullOrWhiteSpace(filterString))
             {
@@ -196,13 +196,13 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                 return filters;
             }
 
-            var filterArray = filterString.Split(",");
+            string[] filterArray = filterString.Split(",");
 
             // the filter format sample is
             // "MedicationRequest?status=completed&date=gt2018-07-01T00:00:00Z"
-            foreach (var filter in filterArray)
+            foreach (string filter in filterArray)
             {
-                var parameterIndex = filter.IndexOf("?", StringComparison.Ordinal);
+                int parameterIndex = filter.IndexOf("?", StringComparison.Ordinal);
 
                 if (parameterIndex <= 0 || parameterIndex == filter.Length - 1)
                 {
@@ -212,14 +212,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                         $"The typeFilter segment '{filter}' could not be parsed.");
                 }
 
-                var filterType = filter.Substring(0, parameterIndex);
+                string filterType = filter.Substring(0, parameterIndex);
 
-                var filterParameters = filter.Substring(parameterIndex + 1).Split("&");
-                var parameterTupleList = new List<KeyValuePair<string, string>>();
+                string[] filterParameters = filter.Substring(parameterIndex + 1).Split("&");
+                List<KeyValuePair<string, string>> parameterTupleList = new List<KeyValuePair<string, string>>();
 
-                foreach (var parameter in filterParameters)
+                foreach (string parameter in filterParameters)
                 {
-                    var keyValue = parameter.Split("=");
+                    string[] keyValue = parameter.Split("=");
 
                     if (keyValue.Length != 2)
                     {
@@ -248,7 +248,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
             EnsureArg.IsNotNull(requiredTypes, nameof(requiredTypes));
             EnsureArg.IsNotNull(typeFilters, nameof(typeFilters));
 
-            foreach (var typeFilter in typeFilters)
+            foreach (TypeFilter typeFilter in typeFilters)
             {
                 // The resource type in typeFilter should be in the required types.
                 if (!requiredTypes.Contains(typeFilter.ResourceType))
@@ -259,12 +259,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                 }
 
                 // Validate search parameters
-                var supportedSearchParam = _fhirSpecificationProvider
+                HashSet<string> supportedSearchParam = _fhirSpecificationProvider
                     .GetSearchParametersByResourceType(typeFilter.ResourceType).ToHashSet();
-                foreach (var (param, _) in typeFilter.Parameters)
+                foreach ((string param, string _) in typeFilter.Parameters)
                 {
-                    var splitParams = param.Split(':', '.');
-                    var paramName = splitParams[0];
+                    string[] splitParams = param.Split(':', '.');
+                    string paramName = splitParams[0];
 
                     // the parameter name should be the supported parameter of this resource type.
                     if (paramName != "_has" && !supportedSearchParam.Contains(paramName))

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/GroupMemberExtractor.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/GroupMemberExtractor.cs
@@ -130,12 +130,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                 throw new GroupMemberExtractorException("Failed to extract group members. Reason: The input group id is null or white space.");
             }
 
-            var searchOptions = new ResourceIdSearchOptions(nameof(ResourceType.Group), groupId, queryParameters);
+            ResourceIdSearchOptions searchOptions = new ResourceIdSearchOptions(nameof(ResourceType.Group), groupId, queryParameters);
 
             // If there is an exception thrown while requesting group resource, do nothing about it and the job will crash.
             string fhirBundleResult = await _dataClient.SearchAsync(searchOptions, cancellationToken);
 
-            var parser = new FhirJsonParser();
+            FhirJsonParser parser = new FhirJsonParser();
             Bundle bundle;
             try
             {
@@ -192,9 +192,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                 throw new GroupMemberExtractorException($"Failed to extract group members. Reason: The resource of Group {groupId} is null.");
             }
 
-            var groupResource = (Group)bundle.Entry[0].Resource;
+            Group groupResource = (Group)bundle.Entry[0].Resource;
 
-            var fhirGroupMembershipTime = new FhirDateTime(groupMembershipTime);
+            FhirDateTime fhirGroupMembershipTime = new FhirDateTime(groupMembershipTime);
             foreach (Group.MemberComponent member in groupResource.Member)
             {
                 // only take the member who is active and it is in this group at fhirGroupMembershipTime

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/R4ReferenceParser.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/R4ReferenceParser.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
 
                     try
                     {
-                        var baseUri = new Uri(reference.Substring(0, resourceTypeStartIndex), UriKind.RelativeOrAbsolute);
+                        Uri baseUri = new Uri(reference.Substring(0, resourceTypeStartIndex), UriKind.RelativeOrAbsolute);
                         if (baseUri.IsAbsoluteUri)
                         {
                             if (baseUri.AbsoluteUri == _dataSource.FhirServerUrl)

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/R4ReferenceParser.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/R4ReferenceParser.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
         private static readonly string ResourceTypesPattern = string.Join('|', R4FhirModelInfo.SupportedResources);
         private static readonly string ReferenceCaptureRegexPattern = $@"(?<{ResourceTypeCapture}>{ResourceTypesPattern})\/(?<{ResourceIdCapture}>[A-Za-z0-9\-\.]{{1,64}})(\/_history\/[A-Za-z0-9\-\.]{{1,64}})?";
 
-        private static readonly Regex ReferenceRegex = new Regex(ReferenceCaptureRegexPattern,
+        private static readonly Regex ReferenceRegex = new Regex(
+            ReferenceCaptureRegexPattern,
             RegexOptions.Singleline | RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
         public R4ReferenceParser(

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/R4ReferenceParser.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/R4ReferenceParser.cs
@@ -49,17 +49,17 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                 throw new ReferenceParseException("The reference string is null or white space.");
             }
 
-            var match = ReferenceRegex.Match(reference);
+            Match match = ReferenceRegex.Match(reference);
 
             if (match.Success)
             {
-                var resourceTypeInString = match.Groups[ResourceTypeCapture].Value;
+                string resourceTypeInString = match.Groups[ResourceTypeCapture].Value;
 
                 if (R4FhirModelInfo.IsKnownResource(resourceTypeInString))
                 {
-                    var resourceId = match.Groups[ResourceIdCapture].Value;
+                    string resourceId = match.Groups[ResourceIdCapture].Value;
 
-                    var resourceTypeStartIndex = match.Groups[ResourceTypeCapture].Index;
+                    int resourceTypeStartIndex = match.Groups[ResourceTypeCapture].Index;
 
                     if (resourceTypeStartIndex == 0)
                     {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataProcessor/DataConverter/DefaultSchemaConverter.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataProcessor/DataConverter/DefaultSchemaConverter.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataProcessor.DataConverter
                 throw new ParquetDataProcessorException($"Current FHIR object is not a valid JObject: {schemaNode.GetNodePath()}.");
             }
 
-            var processedObject = new JObject();
+            JObject processedObject = new JObject();
 
             foreach (KeyValuePair<string, JToken> subItem in fhirJObject)
             {
@@ -131,7 +131,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataProcessor.DataConverter
                 throw new ParquetDataProcessorException($"Current FHIR object is not a valid JArray: {schemaNode.GetNodePath()}.");
             }
 
-            var arrayObject = new JArray();
+            JArray arrayObject = new JArray();
             foreach (JToken item in fhirArrayObject)
             {
                 if (schemaNode.IsLeaf)
@@ -166,7 +166,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataProcessor.DataConverter
 
         private JObject ProcessChoiceTypeObject(JToken fhirObject, FhirParquetSchemaNode schemaNode)
         {
-            var choiceRootObject = new JObject();
+            JObject choiceRootObject = new JObject();
             if (schemaNode.IsLeaf)
             {
                 choiceRootObject.Add(schemaNode.Name, ProcessLeafObject(fhirObject, schemaNode));

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataProcessor/ParquetDataProcessor.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataProcessor/ParquetDataProcessor.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataProcessor
                         // Check null again to avoid duplicate initialization.
                         if (_parquetConverter is null)
                         {
-                            var schemaSet = _fhirSchemaManager.GetAllSchemaContent();
+                            Dictionary<string, string> schemaSet = _fhirSchemaManager.GetAllSchemaContent();
                             _parquetConverter = ParquetConverter.CreateWithSchemaSet(schemaSet);
                             _logger.LogInformation($"ParquetDataProcessor initialized successfully with {schemaSet.Count()} parquet schemas.");
                         }
@@ -103,7 +103,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataProcessor
                 processedData = _customSchemaConverter.Convert(inputData, processParameters.ResourceType, cancellationToken);
             }
 
-            var inputContent = string.Join(
+            string inputContent = string.Join(
                 Environment.NewLine,
                 processedData.Values.Select(jsonObject => jsonObject.ToString(Formatting.None))
                          .Where(result => CheckBlockSize(processParameters.SchemaType, result)));
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataProcessor
             // Convert JSON data to parquet stream.
             try
             {
-                var resultStream = ParquetConverter.ConvertJsonToParquet(processParameters.SchemaType, inputContent);
+                Stream resultStream = ParquetConverter.ConvertJsonToParquet(processParameters.SchemaType, inputContent);
                 return Task.FromResult(
                     new StreamBatchData(
                         resultStream,
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataProcessor
 
         private MemoryStream TransformJsonDataToStream(string schemaType, IEnumerable<JObject> inputData)
         {
-            var content = string.Join(
+            string content = string.Join(
                 Environment.NewLine,
                 inputData.Select(jsonObject => jsonObject.ToString(Formatting.None))
                          .Where(result => CheckBlockSize(schemaType, result)));

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Extensions/DictionaryExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Extensions/DictionaryExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Extensions
             EnsureArg.IsNotNull(dic1, nameof(dic1));
             EnsureArg.IsNotNull(dic2, nameof(dic2));
 
-            foreach (var (type, count) in dic2)
+            foreach ((string type, int count) in dic2)
             {
                 dic1 = dic1.AddToDictionary(type, count);
             }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Extensions/ITypedElementExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Extensions/ITypedElementExtensions.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Extensions
 
         public static DateTime? GetLastUpdatedDay(this ITypedElement element)
         {
-            var result = element?.Children(FhirBundleConstants.MetaKey).FirstOrDefault()?.GetPropertyValue(FhirBundleConstants.LastUpdatedKey);
+            object result = element?.Children(FhirBundleConstants.MetaKey).FirstOrDefault()?.GetPropertyValue(FhirBundleConstants.LastUpdatedKey);
             if (result == null)
             {
                 return null;
             }
 
-            var lastUpdateDatetime = DateTimeOffset.Parse(result.ToString());
+            DateTimeOffset lastUpdateDatetime = DateTimeOffset.Parse(result.ToString());
             return new DateTime(lastUpdateDatetime.Year, lastUpdateDatetime.Month, lastUpdateDatetime.Day);
         }
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Extensions/JObjectExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Extensions/JObjectExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Extensions
         /// <returns>The last updated timestamp of the resource.</returns>
         public static DateTimeOffset? GetLastUpdated(this JObject resource)
         {
-            var result =
+            string result =
                 (resource.GetValue(FhirBundleConstants.MetaKey) as JObject)?.Value<string>(FhirBundleConstants.LastUpdatedKey);
             if (result == null)
             {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/FhirBundleParser.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/FhirBundleParser.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Web;
 using Microsoft.Health.Fhir.Synapse.DataClient.Api;
@@ -17,7 +18,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir
         public static IEnumerable<JObject> ExtractResourcesFromBundle(JObject bundle)
         {
             var entries = bundle?.GetValue(FhirBundleConstants.EntryKey) as JArray;
-            var resources = entries?
+            List<JObject> resources = entries?
                 .Select(entry => (entry as JObject)?.GetValue(FhirBundleConstants.EntryResourceKey) as JObject)
                 .ToList();
             return resources ?? new List<JObject>();
@@ -25,7 +26,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir
 
         public static IEnumerable<JObject> GetOperationOutcomes(IEnumerable<JObject> resources)
         {
-            var operationOutcomes = resources.Where(x =>
+            List<JObject> operationOutcomes = resources.Where(x =>
                 x?.GetValue(FhirBundleConstants.ResourceTypeKey)?.ToString() ==
                 FhirBundleConstants.OperationOutcomeKey).ToList();
             return operationOutcomes ?? new List<JObject>();
@@ -36,12 +37,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir
             var links = bundle?.GetValue(FhirBundleConstants.LinkKey) as JArray;
             if (links != null)
             {
-                foreach (var link in links)
+                foreach (JToken link in links)
                 {
-                    var linkRelation = (link as JObject)?.GetValue(FhirBundleConstants.LinkRelationKey)?.Value<string>();
+                    string linkRelation = (link as JObject)?.GetValue(FhirBundleConstants.LinkRelationKey)?.Value<string>();
                     if (string.Equals(linkRelation, FhirBundleConstants.NextLinkValue, StringComparison.OrdinalIgnoreCase))
                     {
-                        var nextLink = (link as JObject)?.GetValue(FhirBundleConstants.LinkUrlKey)?.Value<string>();
+                        string nextLink = (link as JObject)?.GetValue(FhirBundleConstants.LinkUrlKey)?.Value<string>();
                         return ParseContinuationToken(nextLink);
                     }
                 }
@@ -53,7 +54,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir
         public static int ExtractVersionId(JObject bundle)
         {
             var meta = bundle?.GetValue(FhirBundleConstants.MetaKey) as JObject;
-            var versionId = meta?.GetValue(FhirBundleConstants.VersionIdKey)?.Value<int>();
+            int? versionId = meta?.GetValue(FhirBundleConstants.VersionIdKey)?.Value<int>();
             return versionId ?? 0;
         }
 
@@ -64,7 +65,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir
                 return nextUrl;
             }
 
-            var parameters = HttpUtility.ParseQueryString(nextUrl);
+            NameValueCollection parameters = HttpUtility.ParseQueryString(nextUrl);
             return parameters.Get(FhirApiConstants.ContinuationKey);
         }
     }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/FhirBundleParser.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/FhirBundleParser.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir
     {
         public static IEnumerable<JObject> ExtractResourcesFromBundle(JObject bundle)
         {
-            var entries = bundle?.GetValue(FhirBundleConstants.EntryKey) as JArray;
+            JArray entries = bundle?.GetValue(FhirBundleConstants.EntryKey) as JArray;
             List<JObject> resources = entries?
                 .Select(entry => (entry as JObject)?.GetValue(FhirBundleConstants.EntryResourceKey) as JObject)
                 .ToList();
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir
 
         public static string ExtractContinuationToken(JObject bundle)
         {
-            var links = bundle?.GetValue(FhirBundleConstants.LinkKey) as JArray;
+            JArray links = bundle?.GetValue(FhirBundleConstants.LinkKey) as JArray;
             if (links != null)
             {
                 foreach (JToken link in links)
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir
 
         public static int ExtractVersionId(JObject bundle)
         {
-            var meta = bundle?.GetValue(FhirBundleConstants.MetaKey) as JObject;
+            JObject meta = bundle?.GetValue(FhirBundleConstants.MetaKey) as JObject;
             int? versionId = meta?.GetValue(FhirBundleConstants.VersionIdKey)?.Value<int>();
             return versionId ?? 0;
         }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/BaseFhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/BaseFhirSpecificationProvider.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
         /// <returns>The capability data look up result.</returns>
         protected virtual FhirCapabilityData BuildFhirCapabilityData()
         {
-            var metadataOptions = new MetadataOptions();
+            MetadataOptions metadataOptions = new MetadataOptions();
 
             string metaData;
             try
@@ -146,7 +146,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
         protected string LoadEmbeddedSpecification(string specificationName)
         {
             // Dictionary<string, string> embeddedSchema = new Dictionary<string, string>();
-            var executingAssembly = Assembly.GetExecutingAssembly();
+            Assembly executingAssembly = Assembly.GetExecutingAssembly();
             string specificationKey = string.Format("{0}.{1}", executingAssembly.GetName().Name, specificationName);
             using (Stream stream = executingAssembly.GetManifestResourceStream(specificationKey))
             using (StreamReader reader = new StreamReader(stream))

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/BaseFhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/BaseFhirSpecificationProvider.cs
@@ -94,9 +94,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
         protected virtual Dictionary<string, HashSet<string>> BuildCompartmentResourceTypesLookup()
         {
-            var compartmentResourceTypesLookup = new Dictionary<string, HashSet<string>>();
+            Dictionary<string, HashSet<string>> compartmentResourceTypesLookup = new Dictionary<string, HashSet<string>>();
 
-            foreach (var compartmentFile in _compartmentEmbeddedFiles)
+            foreach (string compartmentFile in _compartmentEmbeddedFiles)
             {
                 string compartmentContext;
                 try
@@ -109,8 +109,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                     throw new FhirSpecificationProviderException($"Read compartment file \"{compartmentFile}\" failed. Reason: {ex.Message}.", ex);
                 }
 
-                var subCompartmentResourceTypesLookup = BuildCompartmentResourceTypesLookupFromCompartmentContext(compartmentContext, compartmentFile);
-                foreach (var item in subCompartmentResourceTypesLookup)
+                Dictionary<string, HashSet<string>> subCompartmentResourceTypesLookup = BuildCompartmentResourceTypesLookupFromCompartmentContext(compartmentContext, compartmentFile);
+                foreach (KeyValuePair<string, HashSet<string>> item in subCompartmentResourceTypesLookup)
                 {
                     compartmentResourceTypesLookup.Add(item.Key, item.Value);
                 }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R4FhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R4FhirSpecificationProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
         protected override Dictionary<string, HashSet<string>> BuildCompartmentResourceTypesLookupFromCompartmentContext(string compartmentContext, string compartmentFile)
         {
-            var parser = new FhirJsonParser();
+            FhirJsonParser parser = new FhirJsonParser();
             Dictionary<string, HashSet<string>> compartmentResourceTypesLookup = new Dictionary<string, HashSet<string>>();
 
             CompartmentDefinition compartment;
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
         protected override FhirCapabilityData BuildCapabilityDataFromMetadata(string metaData)
         {
-            var parser = new FhirJsonParser();
+            FhirJsonParser parser = new FhirJsonParser();
 
             CapabilityStatement capabilityStatement;
             try
@@ -165,7 +165,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Read search parameter file \"{_searchParameterEmbeddedFile}\" failed. Reason: {ex.Message}.", ex);
             }
 
-            var parser = new FhirJsonParser();
+            FhirJsonParser parser = new FhirJsonParser();
             Bundle bundle;
             try
             {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R4FhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R4FhirSpecificationProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
         protected override Dictionary<string, HashSet<string>> BuildCompartmentResourceTypesLookupFromCompartmentContext(string compartmentContext, string compartmentFile)
         {
             var parser = new FhirJsonParser();
-            var compartmentResourceTypesLookup = new Dictionary<string, HashSet<string>>();
+            Dictionary<string, HashSet<string>> compartmentResourceTypesLookup = new Dictionary<string, HashSet<string>>();
 
             CompartmentDefinition compartment;
 
@@ -68,10 +68,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to parse compartment definition from file {compartmentFile}.", exception);
             }
 
-            var compartmentType = compartment.Code?.ToString();
+            string compartmentType = compartment.Code?.ToString();
             if (IsValidCompartmentType(compartmentType))
             {
-                var resourceTypes = compartment.Resource?.Where(x => x.Param.Any()).Select(x => x.Code?.ToString()).ToHashSet();
+                HashSet<string> resourceTypes = compartment.Resource?.Where(x => x.Param.Any()).Select(x => x.Code?.ToString()).ToHashSet();
                 if (resourceTypes == null)
                 {
                     _logger.LogInformation($"There is not any resource type defined for compartment type {compartmentType} in file {compartmentFile}");
@@ -106,10 +106,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to parse capability statement from FHIR server metadata.", exception);
             }
 
-            var searchParameters = new Dictionary<string, HashSet<string>>();
-            var searchParameterIds = new Dictionary<string, string>();
+            Dictionary<string, HashSet<string>> searchParameters = new Dictionary<string, HashSet<string>>();
+            Dictionary<string, string> searchParameterIds = new Dictionary<string, string>();
 
-            var rest = capabilityStatement?.Rest;
+            List<CapabilityStatement.RestComponent> rest = capabilityStatement?.Rest;
             if (rest == null || !rest.Any())
             {
                 _diagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
             }
 
-            var resources = rest.First().Resource;
+            List<CapabilityStatement.ResourceComponent> resources = rest.First().Resource;
 
             if (resources == null || !resources.Any())
             {
@@ -126,9 +126,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
             }
 
-            foreach (var resource in resources)
+            foreach (CapabilityStatement.ResourceComponent resource in resources)
             {
-                var type = resource.Type?.ToString();
+                string type = resource.Type?.ToString();
                 if (!string.IsNullOrEmpty(type))
                 {
                     searchParameters[type] = resource.SearchParam.Select(x => x.Name).ToHashSet();
@@ -177,14 +177,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to parse parameter bundle from file {_searchParameterEmbeddedFile}.", exception);
             }
 
-            var searchParameterDefinition = new Dictionary<string, SearchParameter>();
+            Dictionary<string, SearchParameter> searchParameterDefinition = new Dictionary<string, SearchParameter>();
             if (bundle.Entry == null)
             {
                 _logger.LogError($"Failed to build SearchParameterDefinitionLookup from file {_searchParameterEmbeddedFile}, the bundle entry is null.");
                 throw new FhirSpecificationProviderException($"Failed to build SearchParameterDefinitionLookup from file {_searchParameterEmbeddedFile}, the bundle entry is null.");
             }
 
-            foreach (var searchParameter in bundle.Entry.Select(entryComponent => (SearchParameter)entryComponent.Resource))
+            foreach (SearchParameter searchParameter in bundle.Entry.Select(entryComponent => (SearchParameter)entryComponent.Resource))
             {
                 if (searchParameter == null)
                 {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R4FhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R4FhirSpecificationProvider.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, $"Failed to parse compartment definition from file {compartmentFile}. Reason: {exception.Message}");
+                Logger.LogError(exception, $"Failed to parse compartment definition from file {compartmentFile}. Reason: {exception.Message}");
                 throw new FhirSpecificationProviderException($"Failed to parse compartment definition from file {compartmentFile}.", exception);
             }
 
@@ -74,17 +74,17 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 HashSet<string> resourceTypes = compartment.Resource?.Where(x => x.Param.Any()).Select(x => x.Code?.ToString()).ToHashSet();
                 if (resourceTypes == null)
                 {
-                    _logger.LogInformation($"There is not any resource type defined for compartment type {compartmentType} in file {compartmentFile}");
+                    Logger.LogInformation($"There is not any resource type defined for compartment type {compartmentType} in file {compartmentFile}");
                 }
                 else
                 {
                     compartmentResourceTypesLookup.Add(compartmentType, resourceTypes);
-                    _logger.LogInformation($"There are {resourceTypes.Count} resources type pertained to compartment type {compartmentType}.");
+                    Logger.LogInformation($"There are {resourceTypes.Count} resources type pertained to compartment type {compartmentType}.");
                 }
             }
             else
             {
-                _logger.LogInformation($"The compartment type {compartmentType} in file {compartmentFile} isn't a valid compartment type.");
+                Logger.LogInformation($"The compartment type {compartmentType} in file {compartmentFile} isn't a valid compartment type.");
             }
 
             return compartmentResourceTypesLookup;
@@ -101,8 +101,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             }
             catch (Exception exception)
             {
-                _diagnosticLogger.LogError($"Failed to parse capability statement from FHIR server metadata. Reason: {exception.Message}");
-                _logger.LogInformation(exception, $"Failed to parse capability statement from FHIR server metadata. Reason: {exception.Message}");
+                DiagnosticLogger.LogError($"Failed to parse capability statement from FHIR server metadata. Reason: {exception.Message}");
+                Logger.LogInformation(exception, $"Failed to parse capability statement from FHIR server metadata. Reason: {exception.Message}");
                 throw new FhirSpecificationProviderException($"Failed to parse capability statement from FHIR server metadata.", exception);
             }
 
@@ -112,8 +112,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             List<CapabilityStatement.RestComponent> rest = capabilityStatement?.Rest;
             if (rest == null || !rest.Any())
             {
-                _diagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
-                _logger.LogInformation($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
+                DiagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
+                Logger.LogInformation($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
                 throw new FhirSpecificationProviderException($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
             }
 
@@ -121,8 +121,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
             if (resources == null || !resources.Any())
             {
-                _diagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
-                _logger.LogInformation($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
+                DiagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
+                Logger.LogInformation($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
                 throw new FhirSpecificationProviderException($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
             }
 
@@ -138,12 +138,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
             if (!searchParameters.Any())
             {
-                _diagnosticLogger.LogError("There is not any items in the built SearchParametersLookup.");
-                _logger.LogInformation("There is not any items in the built SearchParametersLookup.");
+                DiagnosticLogger.LogError("There is not any items in the built SearchParametersLookup.");
+                Logger.LogInformation("There is not any items in the built SearchParametersLookup.");
                 throw new FhirSpecificationProviderException("There is not any items in the built SearchParametersLookup.");
             }
 
-            _logger.LogInformation($"Build SearchParametersLookup from fhir server metadata successfully.");
+            Logger.LogInformation($"Build SearchParametersLookup from fhir server metadata successfully.");
 
             return new FhirCapabilityData(searchParameters, searchParameterIds);
         }
@@ -161,7 +161,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Read search parameter file \"{SearchParameterEmbeddedFile}\" failed. Reason: {ex.Message}.");
+                Logger.LogError(ex, $"Read search parameter file \"{SearchParameterEmbeddedFile}\" failed. Reason: {ex.Message}.");
                 throw new FhirSpecificationProviderException($"Read search parameter file \"{SearchParameterEmbeddedFile}\" failed. Reason: {ex.Message}.", ex);
             }
 
@@ -173,14 +173,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, $"Failed to parse parameter bundle from file {SearchParameterEmbeddedFile}. Reason: {exception.Message}.");
+                Logger.LogError(exception, $"Failed to parse parameter bundle from file {SearchParameterEmbeddedFile}. Reason: {exception.Message}.");
                 throw new FhirSpecificationProviderException($"Failed to parse parameter bundle from file {SearchParameterEmbeddedFile}.", exception);
             }
 
             Dictionary<string, SearchParameter> searchParameterDefinition = new Dictionary<string, SearchParameter>();
             if (bundle.Entry == null)
             {
-                _logger.LogError($"Failed to build SearchParameterDefinitionLookup from file {SearchParameterEmbeddedFile}, the bundle entry is null.");
+                Logger.LogError($"Failed to build SearchParameterDefinitionLookup from file {SearchParameterEmbeddedFile}, the bundle entry is null.");
                 throw new FhirSpecificationProviderException($"Failed to build SearchParameterDefinitionLookup from file {SearchParameterEmbeddedFile}, the bundle entry is null.");
             }
 
@@ -188,19 +188,19 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             {
                 if (searchParameter == null)
                 {
-                    _logger.LogInformation("The search parameter is null, just ignore it.");
+                    Logger.LogInformation("The search parameter is null, just ignore it.");
                     continue;
                 }
 
                 if (searchParameter.Url == null)
                 {
-                    _logger.LogInformation($"The search parameter URL is null in {searchParameter}, just ignore it.");
+                    Logger.LogInformation($"The search parameter URL is null in {searchParameter}, just ignore it.");
                     continue;
                 }
 
                 if (searchParameterDefinition.ContainsKey(searchParameter.Url))
                 {
-                    _logger.LogError(
+                    Logger.LogError(
                         $"Failed to build SearchParameterDefinitionLookup from file {SearchParameterEmbeddedFile}, there are more than one search parameter definition for {searchParameter.Id} (url: {searchParameter.Url}).");
                     throw new FhirSpecificationProviderException($"Failed to build SearchParameterDefinitionLookup from file {SearchParameterEmbeddedFile}, there are more than one search parameter definition for {searchParameter.Id} (url: {searchParameter.Url}).");
                 }
@@ -208,7 +208,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 searchParameterDefinition[searchParameter.Url] = searchParameter;
             }
 
-            _logger.LogInformation($"Build SearchParameterDefinitionLookup successfully.");
+            Logger.LogInformation($"Build SearchParameterDefinitionLookup successfully.");
 
             return searchParameterDefinition;
         }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R5FhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R5FhirSpecificationProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
         protected override Dictionary<string, HashSet<string>> BuildCompartmentResourceTypesLookupFromCompartmentContext(string compartmentContext, string compartmentFile)
         {
-            var parser = new FhirJsonParser();
+            FhirJsonParser parser = new FhirJsonParser();
             Dictionary<string, HashSet<string>> compartmentResourceTypesLookup = new Dictionary<string, HashSet<string>>();
 
             CompartmentDefinition compartment;
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
         protected override FhirCapabilityData BuildCapabilityDataFromMetadata(string metaData)
         {
-            var parser = new FhirJsonParser();
+            FhirJsonParser parser = new FhirJsonParser();
 
             CapabilityStatement capabilityStatement;
             try

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R5FhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R5FhirSpecificationProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             }
             catch (Exception exception)
             {
-                _logger.LogError(exception, $"Failed to parse compartment definition from file {compartmentFile}. Reason: {exception.Message}");
+                Logger.LogError(exception, $"Failed to parse compartment definition from file {compartmentFile}. Reason: {exception.Message}");
                 throw new FhirSpecificationProviderException($"Failed to parse compartment definition from file {compartmentFile}.", exception);
             }
 
@@ -73,17 +73,17 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 HashSet<string> resourceTypes = compartment.Resource?.Where(x => x.Param.Any()).Select(x => x.Code?.ToString()).ToHashSet();
                 if (resourceTypes == null)
                 {
-                    _logger.LogInformation($"There is not any resource type defined for compartment type {compartmentType} in file {compartmentFile}");
+                    Logger.LogInformation($"There is not any resource type defined for compartment type {compartmentType} in file {compartmentFile}");
                 }
                 else
                 {
                     compartmentResourceTypesLookup.Add(compartmentType, resourceTypes);
-                    _logger.LogInformation($"There are {resourceTypes.Count} resources type pertained to compartment type {compartmentType}.");
+                    Logger.LogInformation($"There are {resourceTypes.Count} resources type pertained to compartment type {compartmentType}.");
                 }
             }
             else
             {
-                _logger.LogInformation($"The compartment type {compartmentType} in file {compartmentFile} isn't a valid compartment type.");
+                Logger.LogInformation($"The compartment type {compartmentType} in file {compartmentFile} isn't a valid compartment type.");
             }
 
             return compartmentResourceTypesLookup;
@@ -100,8 +100,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             }
             catch (Exception exception)
             {
-                _diagnosticLogger.LogError($"Failed to parse capability statement from FHIR server metadata. Reason: {exception.Message}");
-                _logger.LogInformation(exception, $"Failed to parse capability statement from FHIR server metadata. Reason: {exception.Message}");
+                DiagnosticLogger.LogError($"Failed to parse capability statement from FHIR server metadata. Reason: {exception.Message}");
+                Logger.LogInformation(exception, $"Failed to parse capability statement from FHIR server metadata. Reason: {exception.Message}");
                 throw new FhirSpecificationProviderException($"Failed to parse capability statement from FHIR server metadata.", exception);
             }
 
@@ -111,8 +111,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
             List<CapabilityStatement.RestComponent> rest = capabilityStatement?.Rest;
             if (rest == null || !rest.Any())
             {
-                _diagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
-                _logger.LogInformation($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
+                DiagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
+                Logger.LogInformation($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
                 throw new FhirSpecificationProviderException($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
             }
 
@@ -120,8 +120,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
             if (resources == null || !resources.Any())
             {
-                _diagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
-                _logger.LogInformation($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
+                DiagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
+                Logger.LogInformation($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
                 throw new FhirSpecificationProviderException($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
             }
 
@@ -137,12 +137,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 
             if (!searchParameters.Any())
             {
-                _diagnosticLogger.LogError("There is not any items in the built SearchParametersLookup.");
-                _logger.LogInformation("There is not any items in the built SearchParametersLookup.");
+                DiagnosticLogger.LogError("There is not any items in the built SearchParametersLookup.");
+                Logger.LogInformation("There is not any items in the built SearchParametersLookup.");
                 throw new FhirSpecificationProviderException("There is not any items in the built SearchParametersLookup.");
             }
 
-            _logger.LogInformation($"Build SearchParametersLookup from fhir server metadata successfully.");
+            Logger.LogInformation($"Build SearchParametersLookup from fhir server metadata successfully.");
 
             return new FhirCapabilityData(searchParameters, searchParameterIds);
         }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R5FhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R5FhirSpecificationProvider.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
 {
     public class R5FhirSpecificationProvider : BaseFhirSpecificationProvider
     {
+        public R5FhirSpecificationProvider(IFhirDataClient dataClient, IDiagnosticLogger diagnosticLogger, ILogger<R5FhirSpecificationProvider> logger)
+            : base(dataClient, diagnosticLogger, logger)
+        {
+        }
+
         /// <summary>
         /// Download from https://hl7.org/fhir/5.0.0-snapshot1/compartmentdefinition-patient.json.html
         /// </summary>
@@ -29,12 +34,6 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
         /// Download from https://hl7.org/fhir/5.0.0-snapshot1/search-parameters.json, which is defined in https://hl7.org/fhir/5.0.0-snapshot1/searchparameter.html
         /// </summary>
         protected override string SearchParameterEmbeddedFile { get; } = "Specifications.R5.search-parameters.json";
-
-
-        public R5FhirSpecificationProvider(IFhirDataClient dataClient, IDiagnosticLogger diagnosticLogger, ILogger<R5FhirSpecificationProvider> logger)
-            : base(dataClient, diagnosticLogger, logger)
-        {
-        }
 
         public override IEnumerable<string> GetAllResourceTypes()
         {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R5FhirSpecificationProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Fhir/SpecificationProviders/R5FhirSpecificationProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
         protected override Dictionary<string, HashSet<string>> BuildCompartmentResourceTypesLookupFromCompartmentContext(string compartmentContext, string compartmentFile)
         {
             var parser = new FhirJsonParser();
-            var compartmentResourceTypesLookup = new Dictionary<string, HashSet<string>>();
+            Dictionary<string, HashSet<string>> compartmentResourceTypesLookup = new Dictionary<string, HashSet<string>>();
 
             CompartmentDefinition compartment;
 
@@ -68,10 +68,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to parse compartment definition from file {compartmentFile}.", exception);
             }
 
-            var compartmentType = compartment.Code?.ToString();
+            string compartmentType = compartment.Code?.ToString();
             if (IsValidCompartmentType(compartmentType))
             {
-                var resourceTypes = compartment.Resource?.Where(x => x.Param.Any()).Select(x => x.Code?.ToString()).ToHashSet();
+                HashSet<string> resourceTypes = compartment.Resource?.Where(x => x.Param.Any()).Select(x => x.Code?.ToString()).ToHashSet();
                 if (resourceTypes == null)
                 {
                     _logger.LogInformation($"There is not any resource type defined for compartment type {compartmentType} in file {compartmentFile}");
@@ -106,10 +106,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to parse capability statement from FHIR server metadata.", exception);
             }
 
-            var searchParameters = new Dictionary<string, HashSet<string>>();
-            var searchParameterIds = new Dictionary<string, string>();
+            Dictionary<string, HashSet<string>> searchParameters = new Dictionary<string, HashSet<string>>();
+            Dictionary<string, string> searchParameterIds = new Dictionary<string, string>();
 
-            var rest = capabilityStatement?.Rest;
+            List<CapabilityStatement.RestComponent> rest = capabilityStatement?.Rest;
             if (rest == null || !rest.Any())
             {
                 _diagnosticLogger.LogError($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
@@ -117,7 +117,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
             }
 
-            var resources = rest.First().Resource;
+            List<CapabilityStatement.ResourceComponent> resources = rest.First().Resource;
 
             if (resources == null || !resources.Any())
             {
@@ -126,9 +126,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders
                 throw new FhirSpecificationProviderException($"Failed to build SearchParametersLookup: the resource in capabilityStatement is null.");
             }
 
-            foreach (var resource in resources)
+            foreach (CapabilityStatement.ResourceComponent resource in resources)
             {
-                var type = resource.Type?.ToString();
+                string type = resource.Type?.ToString();
                 if (!string.IsNullOrEmpty(type))
                 {
                     searchParameters[type] = resource.SearchParam.Select(x => x.Name).ToHashSet();

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/AzureStorageJobFactory.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/AzureStorageJobFactory.cs
@@ -79,12 +79,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
             if (_metadataStore.IsInitialized())
             {
-                var taskFactoryFuncs =
+                Func<JobInfo, IJob>[] taskFactoryFuncs =
                     new Func<JobInfo, IJob>[] { CreateProcessingTask, CreateOrchestratorTask };
 
-                foreach (var factoryFunc in taskFactoryFuncs)
+                foreach (Func<JobInfo, IJob> factoryFunc in taskFactoryFuncs)
                 {
-                    var job = factoryFunc(jobInfo);
+                    IJob job = factoryFunc(jobInfo);
                     if (job != null)
                     {
                         return job;
@@ -108,7 +108,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 var inputData = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobInputData>(jobInfo.Definition);
                 if (inputData is { JobType: JobType.Orchestrator })
                 {
-                    var currentResult = string.IsNullOrWhiteSpace(jobInfo.Result)
+                    FhirToDataLakeOrchestratorJobResult currentResult = string.IsNullOrWhiteSpace(jobInfo.Result)
                         ? new FhirToDataLakeOrchestratorJobResult()
                         : JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(jobInfo.Result);
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/AzureStorageJobFactory.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/AzureStorageJobFactory.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         {
             try
             {
-                var inputData = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobInputData>(jobInfo.Definition);
+                FhirToDataLakeOrchestratorJobInputData inputData = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobInputData>(jobInfo.Definition);
                 if (inputData is { JobType: JobType.Orchestrator })
                 {
                     FhirToDataLakeOrchestratorJobResult currentResult = string.IsNullOrWhiteSpace(jobInfo.Result)
@@ -141,7 +141,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         {
             try
             {
-                var inputData = JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobInputData>(jobInfo.Definition);
+                FhirToDataLakeProcessingJobInputData inputData = JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobInputData>(jobInfo.Definition);
                 if (inputData is { JobType: JobType.Processing })
                 {
                     return new FhirToDataLakeProcessingJob(

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/AzureTableClientFactory.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/AzureTableClientFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 tableName);
             }
 
-            var tableUri = new Uri(_tableUrl);
+            Uri tableUri = new Uri(_tableUrl);
             TokenCredential tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
 
             return new TableClient(

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/AzureTableClientFactory.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/AzureTableClientFactory.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using Azure.Core;
 using Azure.Data.Tables;
 using EnsureThat;
 using Microsoft.Extensions.Options;
@@ -61,7 +62,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             }
 
             var tableUri = new Uri(_tableUrl);
-            var tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
+            TokenCredential tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
 
             return new TableClient(
                 tableUri,

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/FhirToDataLakeOrchestratorJob.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/FhirToDataLakeOrchestratorJob.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     nextJobEnd = _inputData.DataEndTime;
                 }
 
-                var input = new FhirToDataLakeProcessingJobInputData
+                FhirToDataLakeProcessingJobInputData input = new FhirToDataLakeProcessingJobInputData
                 {
                     JobType = JobType.Processing,
                     ProcessingJobSequenceId = _result.CreatedJobCount,
@@ -236,7 +236,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             {
                 List<PatientWrapper> selectedPatients = toBeProcessedPatients.Skip(_result.NextPatientIndex)
                     .Take(NumberOfPatientsPerProcessingJob).ToList();
-                var input = new FhirToDataLakeProcessingJobInputData
+                FhirToDataLakeProcessingJobInputData input = new FhirToDataLakeProcessingJobInputData
                 {
                     JobType = JobType.Processing,
                     ProcessingJobSequenceId = _result.CreatedJobCount,
@@ -308,7 +308,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 parameters.Add(new KeyValuePair<string, string>(FhirApiConstants.LastUpdatedKey, $"ge{((DateTimeOffset)start).ToInstantString()}"));
             }
 
-            var searchOptions = new BaseSearchOptions(null, parameters);
+            BaseSearchOptions searchOptions = new BaseSearchOptions(null, parameters);
 
             List<KeyValuePair<string, string>> sharedQueryParameters = new List<KeyValuePair<string, string>>(searchOptions.QueryParameters);
 
@@ -377,7 +377,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                         await CommitJobData(latestJobInfo.Id, cancellationToken);
                         if (latestJobInfo.Result != null)
                         {
-                            var processingJobResult =
+                            FhirToDataLakeProcessingJobResult processingJobResult =
                                 JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobResult>(latestJobInfo.Result);
                             _result.TotalResourceCounts =
                                 _result.TotalResourceCounts.ConcatDictionaryCount(processingJobResult.SearchCount);

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/FhirToDataLakeOrchestratorJob.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/FhirToDataLakeOrchestratorJob.cs
@@ -101,8 +101,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     throw new OperationCanceledException();
                 }
 
-                var filterScope = await _filterManager.GetFilterScopeAsync(cancellationToken);
-                var inputs = filterScope switch
+                FilterScope filterScope = await _filterManager.GetFilterScopeAsync(cancellationToken);
+                IAsyncEnumerable<FhirToDataLakeProcessingJobInputData> inputs = filterScope switch
                 {
                     FilterScope.System => GetInputsAsyncForSystem(cancellationToken),
                     FilterScope.Group => GetInputsAsyncForGroup(cancellationToken),
@@ -110,22 +110,22 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                         $"The filterScope {filterScope} isn't supported now.")
                 };
 
-                await foreach (var input in inputs.WithCancellation(cancellationToken))
+                await foreach (FhirToDataLakeProcessingJobInputData input in inputs.WithCancellation(cancellationToken))
                 {
                     while (_result.RunningJobIds.Count >= _maxJobCountInRunningPool)
                     {
                         await WaitRunningJobComplete(progress, cancellationToken);
                     }
 
-                    var jobDefinitions = new[] { JsonConvert.SerializeObject(input) };
-                    var jobInfos = await _queueClient.EnqueueAsync(
+                    string[] jobDefinitions = new[] { JsonConvert.SerializeObject(input) };
+                    IEnumerable<JobInfo> jobInfos = await _queueClient.EnqueueAsync(
                         _jobInfo.QueueType,
                         jobDefinitions,
                         _jobInfo.GroupId,
                         false,
                         false,
                         cancellationToken);
-                    var newJobId = jobInfos.First().Id;
+                    long newJobId = jobInfos.First().Id;
                     _result.CreatedJobCount++;
                     _result.RunningJobIds.Add(newJobId);
 
@@ -190,7 +190,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
         private async IAsyncEnumerable<FhirToDataLakeProcessingJobInputData> GetInputsAsyncForSystem([EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var interval = TimeSpan.FromSeconds(IncrementalOrchestrationIntervalInSeconds);
+            TimeSpan interval = TimeSpan.FromSeconds(IncrementalOrchestrationIntervalInSeconds);
 
             if (_inputData.DataStartTime == null || ((DateTimeOffset)_inputData.DataStartTime).AddMinutes(60) < _inputData.DataEndTime)
             {
@@ -199,7 +199,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
             while (_result.NextJobTimestamp == null || _result.NextJobTimestamp < _inputData.DataEndTime)
             {
-                var nextResourceTimestamp =
+                DateTimeOffset? nextResourceTimestamp =
                     await GetNextTimestamp(_result.NextJobTimestamp ?? _inputData.DataStartTime, _inputData.DataEndTime, cancellationToken);
                 if (nextResourceTimestamp == null)
                 {
@@ -207,7 +207,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     break;
                 }
 
-                var nextJobEnd = (DateTimeOffset)nextResourceTimestamp + interval;
+                DateTimeOffset nextJobEnd = (DateTimeOffset)nextResourceTimestamp + interval;
                 if (nextJobEnd > _inputData.DataEndTime)
                 {
                     nextJobEnd = _inputData.DataEndTime;
@@ -230,11 +230,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         private async IAsyncEnumerable<FhirToDataLakeProcessingJobInputData> GetInputsAsyncForGroup([EnumeratorCancellation] CancellationToken cancellationToken)
         {
             // for group scope, extract patient list from group at first
-            var toBeProcessedPatients = await GetToBeProcessedPatientsAsync(cancellationToken);
+            List<PatientWrapper> toBeProcessedPatients = await GetToBeProcessedPatientsAsync(cancellationToken);
 
             while (_result.NextPatientIndex < toBeProcessedPatients.Count)
             {
-                var selectedPatients = toBeProcessedPatients.Skip(_result.NextPatientIndex)
+                List<PatientWrapper> selectedPatients = toBeProcessedPatients.Skip(_result.NextPatientIndex)
                     .Take(NumberOfPatientsPerProcessingJob).ToList();
                 var input = new FhirToDataLakeProcessingJobInputData
                 {
@@ -253,14 +253,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
         private async Task<List<PatientWrapper>> GetToBeProcessedPatientsAsync(CancellationToken cancellationToken)
         {
-            var groupID = await _filterManager.GetGroupIdAsync(cancellationToken);
+            string groupID = await _filterManager.GetGroupIdAsync(cancellationToken);
 
             // extract patient ids from group
             _logger.LogInformation($"Start extracting patients from group '{groupID}'.");
 
             // For now, the queryParameters is always null.
             // This parameter will be used when we enable filter groups in the future.
-            var patientsHash = (await _groupMemberExtractor.GetGroupPatientsAsync(
+            HashSet<string> patientsHash = (await _groupMemberExtractor.GetGroupPatientsAsync(
                 groupID,
                 null,
                 _inputData.DataEndTime,
@@ -279,7 +279,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
             // set the version id for processed patient
             // the processed patients is empty at the beginning , and will be updated when completing a successful job.
-            var toBeProcessedPatients = patientsHash.Select(patientHash =>
+            List<PatientWrapper> toBeProcessedPatients = patientsHash.Select(patientHash =>
                 new PatientWrapper(
                     patientHash,
                     processedPatientVersions.ContainsKey(patientHash) ? processedPatientVersions[patientHash] : 0)).ToList();
@@ -296,9 +296,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         // get the lastUpdated timestamp of next resource for next processing job
         private async Task<DateTimeOffset?> GetNextTimestamp(DateTimeOffset? start, DateTimeOffset end, CancellationToken cancellationToken)
         {
-            var typeFilters = await _filterManager.GetTypeFiltersAsync(cancellationToken);
+            List<TypeFilter> typeFilters = await _filterManager.GetTypeFiltersAsync(cancellationToken);
 
-            var parameters = new List<KeyValuePair<string, string>>
+            List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.LastUpdatedKey, $"lt{end.ToInstantString()}"),
             };
@@ -310,19 +310,19 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
             var searchOptions = new BaseSearchOptions(null, parameters);
 
-            var sharedQueryParameters = new List<KeyValuePair<string, string>>(searchOptions.QueryParameters);
+            List<KeyValuePair<string, string>> sharedQueryParameters = new List<KeyValuePair<string, string>>(searchOptions.QueryParameters);
 
             DateTimeOffset? nexTimeOffset = null;
-            foreach (var typeFilter in typeFilters)
+            foreach (TypeFilter typeFilter in typeFilters)
             {
                 searchOptions.ResourceType = typeFilter.ResourceType;
                 searchOptions.QueryParameters = new List<KeyValuePair<string, string>>(sharedQueryParameters);
-                foreach (var parameter in typeFilter.Parameters)
+                foreach (KeyValuePair<string, string> parameter in typeFilter.Parameters)
                 {
                     searchOptions.QueryParameters.Add(parameter);
                 }
 
-                var fhirBundleResult = await _dataClient.SearchAsync(searchOptions, cancellationToken);
+                string fhirBundleResult = await _dataClient.SearchAsync(searchOptions, cancellationToken);
 
                 // Parse bundle result.
                 JObject fhirBundleObject;
@@ -332,7 +332,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 }
                 catch (JsonReaderException exception)
                 {
-                    var reason = string.Format(
+                    string reason = string.Format(
                             "Failed to parse fhir search result for '{0}' with search parameters '{1}'.",
                             searchOptions.ResourceType,
                             string.Join(", ", searchOptions.QueryParameters.Select(parameter => $"{parameter.Key}: {parameter.Value}")));
@@ -342,7 +342,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     throw new FhirDataParseException(reason, exception);
                 }
 
-                var fhirResources = FhirBundleParser.ExtractResourcesFromBundle(fhirBundleObject).ToList();
+                List<JObject> fhirResources = FhirBundleParser.ExtractResourcesFromBundle(fhirBundleObject).ToList();
 
                 if (fhirResources.Any() && fhirResources.First().GetLastUpdated() != null)
                 {
@@ -358,12 +358,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
         private async Task WaitRunningJobComplete(IProgress<string> progress, CancellationToken cancellationToken)
         {
-            var completedJobIds = new HashSet<long>();
-            var runningJobs = new List<JobInfo>();
+            HashSet<long> completedJobIds = new HashSet<long>();
+            List<JobInfo> runningJobs = new List<JobInfo>();
 
             runningJobs.AddRange(await _queueClient.GetJobsByIdsAsync(_jobInfo.QueueType, _result.RunningJobIds.ToArray(), false, cancellationToken));
 
-            foreach (var latestJobInfo in runningJobs)
+            foreach (JobInfo latestJobInfo in runningJobs)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/FhirToDataLakeProcessingJob.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/FhirToDataLakeProcessingJob.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     $"ge{((DateTimeOffset)_inputData.DataStartTime).ToInstantString()}"));
             }
 
-            var searchOption = new BaseSearchOptions(null, parameters);
+            BaseSearchOptions searchOption = new BaseSearchOptions(null, parameters);
 
             // retrieve resources for all the type filters.
             await ProcessFiltersAsync(progress, searchOption, cancellationToken);
@@ -291,7 +291,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
                 // create initial compartment search option for this patient,
                 // the resource type and customized parameters of each filter will be set later.
-                var searchOption = new CompartmentSearchOptions(
+                CompartmentSearchOptions searchOption = new CompartmentSearchOptions(
                     FhirConstants.PatientResource,
                     patientId,
                     null,
@@ -349,7 +349,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
         private async Task<JObject> GetPatientResource(string patientId, CancellationToken cancellationToken)
         {
-            var patientSearchOption = new ResourceIdSearchOptions(
+            ResourceIdSearchOptions patientSearchOption = new ResourceIdSearchOptions(
                 FhirConstants.PatientResource,
                 patientId,
                 null);
@@ -541,13 +541,13 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
                 foreach ((string resourceType, List<JObject> resources) in _cacheResult.Resources)
                 {
-                    var batchData = new JsonBatchData(resources);
+                    JsonBatchData batchData = new JsonBatchData(resources);
 
                     List<string> schemaTypes = _fhirSchemaManager.GetSchemaTypes(resourceType);
                     foreach (string schemaType in schemaTypes)
                     {
                         // Convert grouped data to parquet stream
-                        var processParameters = new ProcessParameters(schemaType, resourceType);
+                        ProcessParameters processParameters = new ProcessParameters(schemaType, resourceType);
                         StreamBatchData parquetStream = await _parquetDataProcessor.ProcessAsync(batchData, processParameters, cancellationToken);
                         int skippedCount = batchData.Values.Count() - parquetStream.BatchSize;
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/FhirToDataLakeProcessingJob.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/FhirToDataLakeProcessingJob.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
                 _typeFilters = await _filterManager.GetTypeFiltersAsync(cancellationToken);
 
-                var filterScope = await _filterManager.GetFilterScopeAsync(cancellationToken);
+                FilterScope filterScope = await _filterManager.GetFilterScopeAsync(cancellationToken);
                 switch (filterScope)
                 {
                     case FilterScope.Group:
@@ -190,7 +190,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         {
             // create initial base search option for this task,
             // the resource type and customized parameters of each filter will be set later.
-            var parameters = new List<KeyValuePair<string, string>>
+            List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.LastUpdatedKey, $"lt{_inputData.DataEndTime.ToInstantString()}"),
             };
@@ -210,21 +210,21 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 
         private async Task GroupExecuteAsyncInternal(IProgress<string> progress, CancellationToken cancellationToken)
         {
-            var isPatientResourcesRequired = IsPatientResourcesRequired(_typeFilters);
+            bool isPatientResourcesRequired = IsPatientResourcesRequired(_typeFilters);
 
             // TODO: how to ensure the group is the same?
-            var allPatientIds = await _groupMemberExtractor.GetGroupPatientsAsync(
+            HashSet<string> allPatientIds = await _groupMemberExtractor.GetGroupPatientsAsync(
                 await _filterManager.GetGroupIdAsync(cancellationToken),
                 null,
                 _inputData.DataEndTime,
                 cancellationToken);
 
-            var patientHashToId = allPatientIds.ToDictionary(
+            Dictionary<string, string> patientHashToId = allPatientIds.ToDictionary(
                 TableKeyProvider.CompartmentRowKey,
                 patientId => patientId);
-            foreach (var patientInfo in _inputData.ToBeProcessedPatients)
+            foreach (PatientWrapper patientInfo in _inputData.ToBeProcessedPatients)
             {
-                var lastPatientVersionId = patientInfo.VersionId;
+                long lastPatientVersionId = patientInfo.VersionId;
 
                 if (!patientHashToId.ContainsKey(patientInfo.PatientHash))
                 {
@@ -232,11 +232,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     continue;
                 }
 
-                var patientId = patientHashToId[patientInfo.PatientHash];
+                string patientId = patientHashToId[patientInfo.PatientHash];
 
                 // the patient resource isn't included in compartment search,
                 // so we need additional request to get the patient resource
-                var patientResource = await GetPatientResource(patientId, cancellationToken);
+                JObject patientResource = await GetPatientResource(patientId, cancellationToken);
 
                 // the patient does not exist, skip processing this patient
                 if (patientResource == null)
@@ -244,7 +244,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     continue;
                 }
 
-                var currentPatientVersionId = FhirBundleParser.ExtractVersionId(patientResource);
+                int currentPatientVersionId = FhirBundleParser.ExtractVersionId(patientResource);
 
                 if (currentPatientVersionId == 0)
                 {
@@ -274,10 +274,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 // the version id is 0 for newly patient
                 // for new patient, we will retrieve all its compartments resources from {since}
                 // for processed patient, we will only retrieve the updated compartment resources from last scheduled time
-                var startDateTime = lastPatientVersionId == 0
+                DateTimeOffset? startDateTime = lastPatientVersionId == 0
                     ? _inputData.Since
                     : _inputData.DataStartTime;
-                var parameters = new List<KeyValuePair<string, string>>
+                List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>
                             {
                                 new (FhirApiConstants.LastUpdatedKey, $"lt{_inputData.DataEndTime.ToInstantString()}"),
                             };
@@ -309,7 +309,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         /// </summary>
         private static bool IsPatientResourcesRequired(IEnumerable<TypeFilter> typeFilters)
         {
-            foreach (var typeFilter in typeFilters)
+            foreach (TypeFilter typeFilter in typeFilters)
             {
                 switch (typeFilter.ResourceType)
                 {
@@ -324,7 +324,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                             return true;
                         }
 
-                        foreach (var (param, value) in typeFilter.Parameters)
+                        foreach ((string param, string value) in typeFilter.Parameters)
                         {
                             if (param != FhirApiConstants.TypeKey)
                             {
@@ -332,7 +332,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                             }
 
                             // if patient is in _type parameter
-                            var types = value.Split(',');
+                            string[] types = value.Split(',');
                             if (types.Contains(FhirConstants.PatientResource))
                             {
                                 return true;
@@ -354,7 +354,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 patientId,
                 null);
 
-            var searchResult = await ExecuteSearchAsync(patientSearchOption, cancellationToken);
+            SearchResult searchResult = await ExecuteSearchAsync(patientSearchOption, cancellationToken);
 
             // if the patient does not exist, log a warning, and do nothing about it.
             if (searchResult.FhirResources == null || !searchResult.FhirResources.Any())
@@ -363,7 +363,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 return null;
             }
 
-            var patientResource = searchResult.FhirResources[0];
+            JObject patientResource = searchResult.FhirResources[0];
 
             if (patientResource["resourceType"]?.ToString() != FhirConstants.PatientResource)
             {
@@ -383,13 +383,13 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             BaseSearchOptions searchOptions,
             CancellationToken cancellationToken)
         {
-            var sharedQueryParameters = new List<KeyValuePair<string, string>>(searchOptions.QueryParameters);
+            List<KeyValuePair<string, string>> sharedQueryParameters = new List<KeyValuePair<string, string>>(searchOptions.QueryParameters);
 
-            foreach (var typeFilter in _typeFilters)
+            foreach (TypeFilter typeFilter in _typeFilters)
             {
                 searchOptions.ResourceType = typeFilter.ResourceType;
                 searchOptions.QueryParameters = new List<KeyValuePair<string, string>>(sharedQueryParameters);
-                foreach (var parameter in typeFilter.Parameters)
+                foreach (KeyValuePair<string, string> parameter in typeFilter.Parameters)
                 {
                     searchOptions.QueryParameters.Add(parameter);
                 }
@@ -407,7 +407,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             BaseSearchOptions searchOptions,
             CancellationToken cancellationToken)
         {
-            var isCurrentSearchCompleted = false;
+            bool isCurrentSearchCompleted = false;
             string continuationToken = null;
 
             while (!isCurrentSearchCompleted)
@@ -420,10 +420,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 // add/update continuation token
                 if (continuationToken != null)
                 {
-                    var replacedContinuationToken = false;
+                    bool replacedContinuationToken = false;
 
                     // if continuation token parameter exists, update it
-                    for (var index = 0; index < searchOptions.QueryParameters.Count; index++)
+                    for (int index = 0; index < searchOptions.QueryParameters.Count; index++)
                     {
                         if (searchOptions.QueryParameters[index].Key != FhirApiConstants.ContinuationKey)
                         {
@@ -443,7 +443,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                     }
                 }
 
-                var searchResult = await ExecuteSearchAsync(searchOptions, cancellationToken);
+                SearchResult searchResult = await ExecuteSearchAsync(searchOptions, cancellationToken);
 
                 // add resources to memory cache
                 AddFhirResourcesToCache(searchResult.FhirResources);
@@ -467,7 +467,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         /// </summary>
         private async Task<SearchResult> ExecuteSearchAsync(BaseSearchOptions searchOptions, CancellationToken cancellationToken)
         {
-            var fhirBundleResult = await _dataClient.SearchAsync(searchOptions, cancellationToken);
+            string fhirBundleResult = await _dataClient.SearchAsync(searchOptions, cancellationToken);
 
             // Parse bundle result.
             JObject fhirBundleObject;
@@ -482,9 +482,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 throw new FhirDataParseException($"Failed to parse fhir search result", exception);
             }
 
-            var fhirResources = FhirBundleParser.ExtractResourcesFromBundle(fhirBundleObject);
+            IEnumerable<JObject> fhirResources = FhirBundleParser.ExtractResourcesFromBundle(fhirBundleObject);
 
-            var operationOutcomes = FhirBundleParser.GetOperationOutcomes(fhirResources).ToList();
+            List<JObject> operationOutcomes = FhirBundleParser.GetOperationOutcomes(fhirResources).ToList();
             if (operationOutcomes.Any())
             {
                 _diagnosticLogger.LogError($"There is operationOutcome returned from FHIR server: {string.Join(',', operationOutcomes)}");
@@ -492,7 +492,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 throw new FhirSearchException($"There is operationOutcome returned from FHIR server: {string.Join(',', operationOutcomes)}");
             }
 
-            var continuationToken = FhirBundleParser.ExtractContinuationToken(fhirBundleObject);
+            string continuationToken = FhirBundleParser.ExtractContinuationToken(fhirBundleObject);
 
             return new SearchResult(fhirResources.ToList(), fhirBundleResult.Length * sizeof(char), continuationToken);
         }
@@ -502,9 +502,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         /// </summary>
         private void AddFhirResourcesToCache(List<JObject> fhirResources)
         {
-            foreach (var resource in fhirResources)
+            foreach (JObject resource in fhirResources)
             {
-                var resourceType = resource["resourceType"]?.ToString();
+                string resourceType = resource["resourceType"]?.ToString();
                 if (string.IsNullOrWhiteSpace(resourceType))
                 {
                     _diagnosticLogger.LogError($"Failed to parse fhir search resource {resource}");
@@ -532,24 +532,24 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             bool forceCommit,
             CancellationToken cancellationToken)
         {
-            var cacheResourceCount = _cacheResult.GetResourceCount();
+            int cacheResourceCount = _cacheResult.GetResourceCount();
             if (cacheResourceCount >= JobConfigurationConstants.NumberOfResourcesPerCommit ||
                 _cacheResult.CacheSize > JobConfigurationConstants.DataSizeInBytesPerCommit ||
                 forceCommit)
             {
                 _logger.LogInformation($"commit data: {cacheResourceCount} resources, {_cacheResult.CacheSize} data size.");
 
-                foreach (var (resourceType, resources) in _cacheResult.Resources)
+                foreach ((string resourceType, List<JObject> resources) in _cacheResult.Resources)
                 {
                     var batchData = new JsonBatchData(resources);
 
-                    var schemaTypes = _fhirSchemaManager.GetSchemaTypes(resourceType);
-                    foreach (var schemaType in schemaTypes)
+                    List<string> schemaTypes = _fhirSchemaManager.GetSchemaTypes(resourceType);
+                    foreach (string schemaType in schemaTypes)
                     {
                         // Convert grouped data to parquet stream
                         var processParameters = new ProcessParameters(schemaType, resourceType);
-                        var parquetStream = await _parquetDataProcessor.ProcessAsync(batchData, processParameters, cancellationToken);
-                        var skippedCount = batchData.Values.Count() - parquetStream.BatchSize;
+                        StreamBatchData parquetStream = await _parquetDataProcessor.ProcessAsync(batchData, processParameters, cancellationToken);
+                        int skippedCount = batchData.Values.Count() - parquetStream.BatchSize;
 
                         if (parquetStream?.Value?.Length > 0)
                         {
@@ -559,7 +559,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                             }
 
                             // Upload to blob and log result
-                            var blobUrl = await _dataWriter.WriteAsync(parquetStream, _jobId, _outputFileIndexMap[schemaType], _inputData.DataEndTime, cancellationToken);
+                            string blobUrl = await _dataWriter.WriteAsync(parquetStream, _jobId, _outputFileIndexMap[schemaType], _inputData.DataEndTime, cancellationToken);
                             _outputFileIndexMap[schemaType] += 1;
 
                             _logger.LogInformation(

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/JobManager.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/JobManager.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
         {
             _logger.LogInformation("Job manager starts running.");
 
-            using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             Task scheduleTask = _scheduler.RunAsync(cancellationTokenSource.Token);
 
             // TODO: the max running job count need to be decided after performance test

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/JobManager.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/JobManager.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             _logger.LogInformation("Job manager starts running.");
 
             using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            var scheduleTask = _scheduler.RunAsync(cancellationTokenSource.Token);
+            Task scheduleTask = _scheduler.RunAsync(cancellationTokenSource.Token);
 
             // TODO: the max running job count need to be decided after performance test
             _jobHosting.MaxRunningJobCount = (short)_jobConfiguration.MaxRunningJobCount;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/SchedulerService.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/SchedulerService.cs
@@ -563,7 +563,6 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             _logger.LogInformation(isSucceeded
                 ? $"Scheduler instance {_instanceGuid} renews lease successfully."
                 : $"Scheduler instance {_instanceGuid} fails to renew lease, failed to update lease trigger entity: {triggerLeaseEntity}.");
-            
             return isSucceeded;
         }
     }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Microsoft.Health.Fhir.Synapse.Core.csproj
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Microsoft.Health.Fhir.Synapse.Core.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Health.Parquet" Version="$(ParquetNativeLibVersion)" />
+    <PackageReference Include="Microsoft.Health.Parquet" Version="1.0.0.215" />
     <PackageReference Include="NCrontab.Signed" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Hl7.Fhir.R5" Version="4.2.1">

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/PipelineRegistrationExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/PipelineRegistrationExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core
 
             services.AddSingleton<IGroupMemberExtractor, GroupMemberExtractor>();
 
-            var filterLocation = services
+            FilterLocation filterLocation = services
                     .BuildServiceProvider()
                     .GetRequiredService<IOptions<FilterLocation>>()
                     .Value;
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core
 
         public static IServiceCollection AddFhirSpecificationProvider(this IServiceCollection services)
         {
-            var fhirServerConfiguration = services
+            FhirServerConfiguration fhirServerConfiguration = services
                 .BuildServiceProvider()
                 .GetRequiredService<IOptions<FhirServerConfiguration>>()
                 .Value;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/AzureAccessTokenProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/AzureAccessTokenProvider.cs
@@ -23,9 +23,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
         private readonly IDiagnosticLogger _diagnosticLogger;
         private readonly ILogger<AzureAccessTokenProvider> _logger;
         private readonly TokenCredential _tokenCredential;
-        private ConcurrentDictionary<string, AccessToken> _accessTokenDic =
-            new ConcurrentDictionary<string, AccessToken>();
-        private const int _tokenExpireInterval = 5;
+        private ConcurrentDictionary<string, AccessToken> _accessTokenDic = new ConcurrentDictionary<string, AccessToken>();
+        private const int TokenExpireInterval = 5;
 
         public AzureAccessTokenProvider(TokenCredential tokenCredential, IDiagnosticLogger diagnosticLogger, ILogger<AzureAccessTokenProvider> logger)
         {
@@ -44,7 +43,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
 
             try
             {
-                if (!_accessTokenDic.TryGetValue(resourceUrl, out AccessToken accessToken) || string.IsNullOrEmpty(accessToken.Token) || accessToken.ExpiresOn < DateTime.UtcNow.AddMinutes(_tokenExpireInterval))
+                if (!_accessTokenDic.TryGetValue(resourceUrl, out AccessToken accessToken) || string.IsNullOrEmpty(accessToken.Token) || accessToken.ExpiresOn < DateTime.UtcNow.AddMinutes(TokenExpireInterval))
                 {
                     string[] scopes = new string[] { resourceUrl.TrimEnd('/') + "/.default" };
                     accessToken = await _tokenCredential.GetTokenAsync(new TokenRequestContext(scopes), cancellationToken);

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/AzureAccessTokenProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/AzureAccessTokenProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
             {
                 if (!_accessTokenDic.TryGetValue(resourceUrl, out AccessToken accessToken) || string.IsNullOrEmpty(accessToken.Token) || accessToken.ExpiresOn < DateTime.UtcNow.AddMinutes(_tokenExpireInterval))
                 {
-                    var scopes = new string[] { resourceUrl.TrimEnd('/') + "/.default" };
+                    string[] scopes = new string[] { resourceUrl.TrimEnd('/') + "/.default" };
                     accessToken = await _tokenCredential.GetTokenAsync(new TokenRequestContext(scopes), cancellationToken);
                     _accessTokenDic.AddOrUpdate(resourceUrl, accessToken, (key, value) => accessToken);
                 }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
 
         private Uri CreateSearchUri(BaseFhirApiOptions fhirApiOptions)
         {
-            var serverUrl = _dataSource.FhirServerUrl;
+            string serverUrl = _dataSource.FhirServerUrl;
 
             var baseUri = new Uri(serverUrl);
 
@@ -152,7 +152,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
             uri = uri.AddQueryString(fhirApiOptions.QueryParameters);
 
             // add shared parameters _count
-            var queryParameters = new List<KeyValuePair<string, string>>
+            List<KeyValuePair<string, string>> queryParameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.PageCountKey, FhirApiConstants.PageCount.ToString()),
             };
@@ -176,8 +176,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
                     searchRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 }
 
-                var retryCount = 0;
-                var retry = true;
+                int retryCount = 0;
+                bool retry = true;
                 HttpResponseMessage response = await _httpClient.SendAsync(searchRequest, cancellationToken);
                 while (retry)
                 {
@@ -250,7 +250,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
                 response.EnsureSuccessStatusCode();
                 _logger.LogInformation("Successfully retrieved result for url: '{url}'.", uri);
 
-                var stream = response.Content.ReadAsStream();
+                Stream stream = response.Content.ReadAsStream();
                 stream.Seek(0, SeekOrigin.Begin);
                 StreamReader reader = new StreamReader(stream);
                 return reader.ReadToEnd();

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
@@ -139,9 +139,9 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
         {
             string serverUrl = _dataSource.FhirServerUrl;
 
-            var baseUri = new Uri(serverUrl);
+            Uri baseUri = new Uri(serverUrl);
 
-            var uri = new Uri(baseUri, fhirApiOptions.RelativeUri());
+            Uri uri = new Uri(baseUri, fhirApiOptions.RelativeUri());
 
             // the query parameters is null for metadata
             if (fhirApiOptions.QueryParameters == null)
@@ -164,7 +164,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
         {
             try
             {
-                var searchRequest = new HttpRequestMessage(HttpMethod.Get, uri);
+                HttpRequestMessage searchRequest = new HttpRequestMessage(HttpMethod.Get, uri);
                 if (accessToken != null)
                 {
                     // Currently we support accessing FHIR server endpoints with Managed Identity.
@@ -244,7 +244,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
         {
             try
             {
-                var searchRequest = new HttpRequestMessage(HttpMethod.Get, uri);
+                HttpRequestMessage searchRequest = new HttpRequestMessage(HttpMethod.Get, uri);
 
                 HttpResponseMessage response = _httpClient.Send(searchRequest);
                 response.EnsureSuccessStatusCode();

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/DataClientRegistrationExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/DataClientRegistrationExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient
             services.AddSingleton<IFhirApiDataSource, FhirApiDataSource>();
             services.AddSingleton<IFhirDataClient, FhirApiDataClient>();
 
-            var fhirServerConfiguration = services
+            FhirServerConfiguration fhirServerConfiguration = services
                 .BuildServiceProvider()
                 .GetRequiredService<IOptions<FhirServerConfiguration>>()
                 .Value;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Extensions/UriExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Extensions/UriExtensions.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Web;
 
 namespace Microsoft.Health.Fhir.Synapse.DataClient.Extensions
@@ -20,8 +21,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Extensions
         public static Uri AddQueryString(this Uri uri, IEnumerable<KeyValuePair<string, string>> parameters)
         {
             var uriBuilder = new UriBuilder(uri);
-            var query = HttpUtility.ParseQueryString(uriBuilder.Query);
-            foreach (var parameter in parameters)
+            NameValueCollection query = HttpUtility.ParseQueryString(uriBuilder.Query);
+            foreach (KeyValuePair<string, string> parameter in parameters)
             {
                 query.Add(parameter.Key, parameter.Value);
             }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Extensions/UriExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Extensions/UriExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Extensions
         /// <returns>new Uri with expected query string.</returns>
         public static Uri AddQueryString(this Uri uri, IEnumerable<KeyValuePair<string, string>> parameters)
         {
-            var uriBuilder = new UriBuilder(uri);
+            UriBuilder uriBuilder = new UriBuilder(uri);
             NameValueCollection query = HttpUtility.ParseQueryString(uriBuilder.Query);
             foreach (KeyValuePair<string, string> parameter in parameters)
             {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataWriter/Azure/AzureBlobContainerClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataWriter/Azure/AzureBlobContainerClient.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.Azure
         /// </summary>
         /// <param name="connectionString">Storage connection string.</param>
         /// <param name="containerName">Container name.</param>
+        /// <param name="diagnosticLogger">diagnostic logger</param>
         /// <param name="logger">logger.</param>
         public AzureBlobContainerClient(
             string connectionString,

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataWriter/Azure/AzureBlobContainerClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataWriter/Azure/AzureBlobContainerClient.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.Azure
             _diagnosticLogger = diagnosticLogger;
             _logger = logger;
 
-            var blobContainerClient = new BlobContainerClient(
+            BlobContainerClient blobContainerClient = new BlobContainerClient(
                 connectionString,
                 containerName);
             InitializeBlobContainerClient(blobContainerClient);
@@ -110,7 +110,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.Azure
                             try
                             {
                                 TokenCredential externalTokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.External);
-                                var tempBlobContainerClient = new BlobContainerClient(
+                                BlobContainerClient tempBlobContainerClient = new BlobContainerClient(
                                     _storageUri,
                                     externalTokenCredential);
 
@@ -210,7 +210,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.Azure
             BlobClient blobClient = BlobContainerClient.GetBlobClient(blobName);
             try
             {
-                var stream = new MemoryStream();
+                MemoryStream stream = new MemoryStream();
                 await blobClient.DownloadToAsync(stream, cancellationToken);
                 stream.Seek(0, SeekOrigin.Begin);
                 return stream;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataWriter/Azure/AzureBlobContainerClientFactory.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataWriter/Azure/AzureBlobContainerClientFactory.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.Azure
                 return new AzureBlobContainerClient(_externalConnectionString, containerName, _diagnosticLogger, _loggerFactory.CreateLogger<AzureBlobContainerClient>());
             }
 
-            var storageUri = new Uri(storeUrl);
-            var containerUrl = new Uri(storageUri, containerName);
+            Uri storageUri = new Uri(storeUrl);
+            Uri containerUrl = new Uri(storageUri, containerName);
 
             return new AzureBlobContainerClient(
                 containerUrl,

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/JobManagerFunction.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/JobManagerFunction.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Synapse.FunctionApp
         [Function("JobManagerFunction")]
         public async Task Run(FunctionContext context)
         {
-            var logger = context.GetLogger("JobManagerFunction");
+            ILogger logger = context.GetLogger("JobManagerFunction");
             logger.LogInformation("C# Timer trigger function executed at: {time}", DateTime.Now);
 
             try

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/Microsoft.Health.Fhir.Synapse.FunctionApp.csproj
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/Microsoft.Health.Fhir.Synapse.FunctionApp.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Health.Parquet" Version="$(ParquetNativeLibVersion)" />
+    <PackageReference Include="Microsoft.Health.Parquet" Version="1.0.0.215" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Health.Fhir.Synapse.Common\Microsoft.Health.Fhir.Synapse.Common.csproj" />

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/Program.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/Program.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Synapse.FunctionApp
     {
         public static void Main()
         {
-            var host = new HostBuilder()
+            IHost host = new HostBuilder()
                 .ConfigureAppConfiguration((builder) =>
                 {
                     builder.AddJsonFile("appsettings.json");

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureBlobStorageHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureBlobStorageHealthChecker.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
             }
             catch (Exception e)
             {
-                _logger.LogInformation(e, $"Health check component {HealthCheckTypes.AzureBlobStorageCanReadWrite}: write content to storage account failed: {e}.");
+                Logger.LogInformation(e, $"Health check component {HealthCheckTypes.AzureBlobStorageCanReadWrite}: write content to storage account failed: {e}.");
 
                 healthCheckResult.Status = HealthCheckStatus.UNHEALTHY;
                 healthCheckResult.ErrorMessage = $"Write content to blob failed. {e.Message}";
@@ -81,7 +81,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
             }
             catch (Exception e)
             {
-                _logger.LogInformation(e, $"Health check component {HealthCheckTypes.AzureBlobStorageCanReadWrite}: read content from storage account failed: {e}.");
+                Logger.LogInformation(e, $"Health check component {HealthCheckTypes.AzureBlobStorageCanReadWrite}: read content from storage account failed: {e}.");
 
                 healthCheckResult.Status = HealthCheckStatus.UNHEALTHY;
                 healthCheckResult.ErrorMessage = $"Read content from blob failed. {e.Message}";
@@ -96,7 +96,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
             }
             catch (Exception e)
             {
-                _logger.LogInformation(e, $"Health check component {HealthCheckTypes.AzureBlobStorageCanReadWrite}: check hierachical namespace enabled in storage account failed: {e}.");
+                Logger.LogInformation(e, $"Health check component {HealthCheckTypes.AzureBlobStorageCanReadWrite}: check hierachical namespace enabled in storage account failed: {e}.");
 
                 healthCheckResult.Status = HealthCheckStatus.UNHEALTHY;
                 healthCheckResult.ErrorMessage = $"Check hierachical namespace enabled in storage account failed. {e.Message}";

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureBlobStorageHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureBlobStorageHealthChecker.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
 
         protected override async Task<HealthCheckResult> PerformHealthCheckImplAsync(CancellationToken cancellationToken)
         {
-            var healthCheckResult = new HealthCheckResult(HealthCheckTypes.AzureBlobStorageCanReadWrite);
+            HealthCheckResult healthCheckResult = new HealthCheckResult(HealthCheckTypes.AzureBlobStorageCanReadWrite);
             string blobPath = $"{_sourceFolderName}/{HealthCheckBlobPrefix}";
 
             try

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureBlobStorageHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureBlobStorageHealthChecker.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
         protected override async Task<HealthCheckResult> PerformHealthCheckImplAsync(CancellationToken cancellationToken)
         {
             var healthCheckResult = new HealthCheckResult(HealthCheckTypes.AzureBlobStorageCanReadWrite);
-            var blobPath = $"{_sourceFolderName}/{HealthCheckBlobPrefix}";
+            string blobPath = $"{_sourceFolderName}/{HealthCheckBlobPrefix}";
 
             try
             {
@@ -122,7 +122,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
 
         private async Task<string> DownloadFromBlobAsync(string blobPath, CancellationToken cancellationToken)
         {
-            using var resultStream = await _blobContainerClient.GetBlobAsync(blobPath, cancellationToken: cancellationToken);
+            using Stream resultStream = await _blobContainerClient.GetBlobAsync(blobPath, cancellationToken: cancellationToken);
             resultStream.Position = 0;
             using StreamReader reader = new (resultStream, Encoding.UTF8);
             return reader.ReadToEnd();

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureContainerRegistryHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureContainerRegistryHealthChecker.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
             try
             {
                 var imageInfo = ImageInfo.CreateFromImageReference(_imageReference);
-                var accessToken = await _containerRegistryTokenProvider.GetTokenAsync(imageInfo.Registry, cancellationToken);
+                string accessToken = await _containerRegistryTokenProvider.GetTokenAsync(imageInfo.Registry, cancellationToken);
                 var acrClient = new AzureContainerRegistryClient(imageInfo.Registry, new AcrClientCredentials(accessToken));
 
                 // Ensure we can read from acr.

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureContainerRegistryHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureContainerRegistryHealthChecker.cs
@@ -40,13 +40,13 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
 
         protected override async Task<HealthCheckResult> PerformHealthCheckImplAsync(CancellationToken cancellationToken)
         {
-            var healthCheckResult = new HealthCheckResult(_name, false);
+            HealthCheckResult healthCheckResult = new HealthCheckResult(_name, false);
 
             try
             {
-                var imageInfo = ImageInfo.CreateFromImageReference(_imageReference);
+                ImageInfo imageInfo = ImageInfo.CreateFromImageReference(_imageReference);
                 string accessToken = await _containerRegistryTokenProvider.GetTokenAsync(imageInfo.Registry, cancellationToken);
-                var acrClient = new AzureContainerRegistryClient(imageInfo.Registry, new AcrClientCredentials(accessToken));
+                AzureContainerRegistryClient acrClient = new AzureContainerRegistryClient(imageInfo.Registry, new AcrClientCredentials(accessToken));
 
                 // Ensure we can read from acr.
                 await acrClient.Manifests.GetAsync(imageInfo.ImageName, imageInfo.Label, MediatypeV2Manifest, cancellationToken);

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureContainerRegistryHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/AzureContainerRegistryHealthChecker.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
             }
             catch (Exception e)
             {
-                _logger.LogInformation(e, $"Health check component {_name}: read ACR {_imageReference} failed: {e}.");
+                Logger.LogInformation(e, $"Health check component {_name}: read ACR {_imageReference} failed: {e}.");
                 healthCheckResult.Status = HealthCheckStatus.UNHEALTHY;
                 healthCheckResult.ErrorMessage = $"Read from acr failed. {e.Message}";
                 return healthCheckResult;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/BaseHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/BaseHealthChecker.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
             ILogger<BaseHealthChecker> logger)
         {
             _diagnosticLogger = EnsureArg.IsNotNull(diagnosticLogger, nameof(diagnosticLogger));
-            _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+            Logger = EnsureArg.IsNotNull(logger, nameof(logger));
             Name = EnsureArg.IsNotNullOrWhiteSpace(healthCheckName, nameof(healthCheckName));
             IsCritical = isCritical;
         }
 
-        protected readonly ILogger<BaseHealthChecker> _logger;
+        protected ILogger<BaseHealthChecker> Logger { get; }
 
         public string Name { get; set; }
 
@@ -51,18 +51,18 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
                 };
 
                 _diagnosticLogger.LogError($"Unknown exception occured in health check component {Name}. {e.Message}");
-                _logger.LogInformation(e, $"Unhandled exception occured in health check component {Name}. {e.Message}");
+                Logger.LogInformation(e, $"Unhandled exception occured in health check component {Name}. {e.Message}");
             }
 
             if (healthCheckResult.Status is HealthCheckStatus.UNHEALTHY)
             {
                 _diagnosticLogger.LogWarning($"Health check component {Name} is unhealthy. Failed reason: {healthCheckResult.ErrorMessage}");
-                _logger.LogInformation($"Health check component {Name} is unhealthy. Failed reason: {healthCheckResult.ErrorMessage}");
+                Logger.LogInformation($"Health check component {Name} is unhealthy. Failed reason: {healthCheckResult.ErrorMessage}");
             }
             else
             {
                 _diagnosticLogger.LogInformation($"Health check component {Name} is healthy");
-                _logger.LogInformation($"Health check component {Name} is healthy");
+                Logger.LogInformation($"Health check component {Name} is healthy");
             }
 
             return healthCheckResult;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/FhirServerHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/FhirServerHealthChecker.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
             }
             catch (Exception e)
             {
-                _logger.LogInformation(e, $"Health check component {HealthCheckTypes.FhirServiceCanRead}: read FHIR server failed: {e}.");
+                Logger.LogInformation(e, $"Health check component {HealthCheckTypes.FhirServiceCanRead}: read FHIR server failed: {e}.");
 
                 healthCheckResult.Status = HealthCheckStatus.UNHEALTHY;
                 healthCheckResult.ErrorMessage = "Read from FHIR server failed." + e.Message;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/FhirServerHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/FhirServerHealthChecker.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
 
         protected override async Task<HealthCheckResult> PerformHealthCheckImplAsync(CancellationToken cancellationToken)
         {
-            var healthCheckResult = new HealthCheckResult(HealthCheckTypes.FhirServiceCanRead);
+            HealthCheckResult healthCheckResult = new HealthCheckResult(HealthCheckTypes.FhirServiceCanRead);
 
             try
             {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/SchedulerServiceHealthChecker.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/Checkers/SchedulerServiceHealthChecker.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.Checkers
 
         protected override Task<HealthCheckResult> PerformHealthCheckImplAsync(CancellationToken cancellationToken)
         {
-            var healthCheckResult = new HealthCheckResult(HealthCheckTypes.SchedulerServiceIsActive, true);
+            HealthCheckResult healthCheckResult = new HealthCheckResult(HealthCheckTypes.SchedulerServiceIsActive, true);
 
             if (_schedulerService.LastHeartbeat.AddSeconds(_schedulerServiceInActiveTimeInterval) < DateTimeOffset.UtcNow)
             {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/HealthCheckBackgroundService.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/HealthCheckBackgroundService.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
 using Microsoft.Health.Fhir.Synapse.Common.Logging;
 using Microsoft.Health.Fhir.Synapse.Common.Metrics;
+using Microsoft.Health.Fhir.Synapse.HealthCheck.Models;
 
 namespace Microsoft.Health.Fhir.Synapse.HealthCheck
 {
@@ -50,20 +51,20 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck
             while (!cancellationToken.IsCancellationRequested)
             {
                 // Delay interval time.
-                var delayTask = Task.Delay(_checkIntervalInSeconds, cancellationToken);
+                Task delayTask = Task.Delay(_checkIntervalInSeconds, cancellationToken);
                 try
                 {
                     _diagnosticLogger.LogInformation("Starting to perform health checks");
                     _logger.LogInformation("Starting to perform health checks");
 
                     // Perform health check.
-                    var healthStatus = await _healthCheckEngine.CheckHealthAsync(cancellationToken);
+                    OverallHealthStatus healthStatus = await _healthCheckEngine.CheckHealthAsync(cancellationToken);
 
                     _diagnosticLogger.LogInformation($"Finished health checks: ${string.Join(',', healthStatus.HealthCheckResults.Select(x => x.Name))}.");
                     _logger.LogInformation($"Finished health checks: ${string.Join(',', healthStatus.HealthCheckResults.Select(x => x.Name))}.");
 
                     // Todo: Send notification to mediator and remove listeners here.
-                    var listenerTasks = _healthCheckListeners.Select(l => l.ProcessHealthStatusAsync(healthStatus, cancellationToken)).ToList();
+                    List<Task> listenerTasks = _healthCheckListeners.Select(l => l.ProcessHealthStatusAsync(healthStatus, cancellationToken)).ToList();
                     _metricsLogger.LogHealthStatusMetric(healthStatus.Status == Models.HealthCheckStatus.HEALTHY ? 1 : 0);
                     await Task.WhenAll(listenerTasks);
                     await delayTask;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/HealthCheckEngine.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/HealthCheckEngine.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck
         public async Task<OverallHealthStatus> CheckHealthAsync(CancellationToken cancellationToken = default)
         {
             var healthStatus = new OverallHealthStatus();
-            var tasks = new List<Task<HealthCheckResult>>();
+            List<Task<HealthCheckResult>> tasks = new List<Task<HealthCheckResult>>();
 
             // healthCheckToken will be canceled if health check timeout or cancellationToken is canceled.
             using var healthCheckToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             healthCheckToken.CancelAfter(_healthCheckTimeoutInSeconds);
 
-            foreach (var healthChecker in _healthCheckers)
+            foreach (IHealthChecker healthChecker in _healthCheckers)
             {
                 tasks.Add(healthChecker.PerformHealthCheckAsync(healthCheckToken.Token));
             }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/HealthCheckEngine.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/HealthCheckEngine.cs
@@ -34,11 +34,11 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck
 
         public async Task<OverallHealthStatus> CheckHealthAsync(CancellationToken cancellationToken = default)
         {
-            var healthStatus = new OverallHealthStatus();
+            OverallHealthStatus healthStatus = new OverallHealthStatus();
             List<Task<HealthCheckResult>> tasks = new List<Task<HealthCheckResult>>();
 
             // healthCheckToken will be canceled if health check timeout or cancellationToken is canceled.
-            using var healthCheckToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using CancellationTokenSource healthCheckToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             healthCheckToken.CancelAfter(_healthCheckTimeoutInSeconds);
 
             foreach (IHealthChecker healthChecker in _healthCheckers)

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/HealthCheckerRegistrationExtension.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.HealthCheck/HealthCheckerRegistrationExtension.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck
 
             services.AddSingleton<IHealthChecker, AzureBlobStorageHealthChecker>();
 
-            var schemaConfiguration = services
+            SchemaConfiguration schemaConfiguration = services
                     .BuildServiceProvider()
                     .GetRequiredService<IOptions<SchemaConfiguration>>()
                     .Value;
@@ -31,7 +31,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck
                 services.AddSingleton<IHealthChecker, SchemaAzureContainerRegistryHealthChecker>();
             }
 
-            var filterLocation = services
+            FilterLocation filterLocation = services
                     .BuildServiceProvider()
                     .GetRequiredService<IOptions<FilterLocation>>()
                     .Value;

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/AzureStorageClientFactory.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/AzureStorageClientFactory.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                 return new TableClient(_internalConnectionString, _tableName);
             }
 
-            var tableUri = new Uri(_tableUrl);
+            Uri tableUri = new Uri(_tableUrl);
             TokenCredential? tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
 
             return new TableClient(
@@ -104,7 +104,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                 return new QueueClient(_internalConnectionString, _queueName);
             }
 
-            var queueUri = new Uri($"{_queueUrl}{_queueName}");
+            Uri queueUri = new Uri($"{_queueUrl}{_queueName}");
             TokenCredential? tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
 
             return new QueueClient(

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/AzureStorageClientFactory.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/AzureStorageClientFactory.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using Azure.Core;
 using Azure.Data.Tables;
 using Azure.Storage.Queues;
 using EnsureThat;
@@ -82,7 +83,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             }
 
             var tableUri = new Uri(_tableUrl);
-            var tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
+            TokenCredential? tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
 
             return new TableClient(
                 tableUri,
@@ -104,7 +105,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             }
 
             var queueUri = new Uri($"{_queueUrl}{_queueName}");
-            var tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
+            TokenCredential? tokenCredential = _credentialProvider.GetCredential(TokenCredentialTypes.Internal);
 
             return new QueueClient(
                 queueUri,

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/AzureStorageJobQueueClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/AzureStorageJobQueueClient.cs
@@ -90,10 +90,10 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             }
 
             // step 1: get incremental job ids, will try again if fails
-            var jobIds = await GetIncrementalJobIds(queueType, definitions.Length, cancellationToken);
+            List<long> jobIds = await GetIncrementalJobIds(queueType, definitions.Length, cancellationToken);
 
             // step 2: generate job info entities and job lock entities batch
-            var jobInfos = definitions.Select((definition, i) => new TJobInfo
+            List<TJobInfo> jobInfos = definitions.Select((definition, i) => new TJobInfo
                 {
                     Id = jobIds[i],
                     QueueType = queueType,
@@ -107,15 +107,15 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                 })
                 .ToList();
 
-            var jobInfoEntities = jobInfos.Select(jobInfo => jobInfo.ToTableEntity()).ToList();
-            var jobLockEntities = jobInfoEntities.Select((jobInfoEntity, i) =>
+            List<TableEntity> jobInfoEntities = jobInfos.Select(jobInfo => jobInfo.ToTableEntity()).ToList();
+            List<TableEntity> jobLockEntities = jobInfoEntities.Select((jobInfoEntity, i) =>
                 new TableEntity(jobInfoEntity.PartitionKey, AzureStorageKeyProvider.JobLockRowKey(jobInfos[i].JobIdentifier()))
                 {
                     { JobLockEntityProperties.JobInfoEntityRowKey, jobInfoEntity.RowKey },
                 }).ToList();
 
             // step 3: insert jobInfo entity and job lock entity in one transaction.
-            var transactionActions = jobInfoEntities
+            IEnumerable<TableTransactionAction> transactionActions = jobInfoEntities
                 .Select(entity => new TableTransactionAction(TableTransactionActionType.Add, entity))
                 .Concat(jobLockEntities.Select(entity => new TableTransactionAction(TableTransactionActionType.Add, entity)));
             try
@@ -131,12 +131,12 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             {
                 // step 4: get the existing job lock entities and jobInfo entities
                 // need to get job lock entity firstly to get the jobInfo entity row key
-                var jobEntityQueryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
+                AsyncPageable<TableEntity>? jobEntityQueryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
                     filter: TransactionGetByKeys(jobLockEntities.First().PartitionKey, jobLockEntities.Select(entity => entity.RowKey).ToList()),
                     cancellationToken: cancellationToken);
 
-                var retrievedJobLockEntities = new List<TableEntity>();
-                await foreach (var pageResult in jobEntityQueryResult.AsPages().WithCancellation(cancellationToken))
+                List<TableEntity> retrievedJobLockEntities = new List<TableEntity>();
+                await foreach (Page<TableEntity> pageResult in jobEntityQueryResult.AsPages().WithCancellation(cancellationToken))
                 {
                     retrievedJobLockEntities.AddRange(pageResult.Values);
                 }
@@ -154,8 +154,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                     filter: TransactionGetByKeys(jobLockEntities.First().PartitionKey, jobLockEntities.Select(entity => entity.GetString(JobLockEntityProperties.JobInfoEntityRowKey)).ToList()),
                     cancellationToken: cancellationToken);
 
-                var retrievedJobInfoEntities = new List<TableEntity>();
-                await foreach (var pageResult in jobEntityQueryResult.AsPages().WithCancellation(cancellationToken))
+                List<TableEntity> retrievedJobInfoEntities = new List<TableEntity>();
+                await foreach (Page<TableEntity> pageResult in jobEntityQueryResult.AsPages().WithCancellation(cancellationToken))
                 {
                     retrievedJobInfoEntities.AddRange(pageResult.Values);
                 }
@@ -203,12 +203,12 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                 // for new added job lock entities, their etag are empty, need to get them to get etag.
                 if (jobLockEntities.Any(jobLockEntity => string.IsNullOrWhiteSpace(jobLockEntity.ETag.ToString())))
                 {
-                    var jobLockEntityQueryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
+                    AsyncPageable<TableEntity>? jobLockEntityQueryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
                         filter: TransactionGetByKeys(jobLockEntities.First().PartitionKey, jobLockEntities.Select(entity => entity.RowKey).ToList()),
                         cancellationToken: cancellationToken);
 
                     jobLockEntities.Clear();
-                    await foreach (var pageResult in jobLockEntityQueryResult.AsPages().WithCancellation(cancellationToken))
+                    await foreach (Page<TableEntity> pageResult in jobLockEntityQueryResult.AsPages().WithCancellation(cancellationToken))
                     {
                         jobLockEntities.AddRange(pageResult.Values);
                     }
@@ -219,9 +219,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                 // we don't resend message for it, and return the existing jobInfo, so will do noting about it
                 if (jobLockEntities.Any(jobLockEntity => !jobLockEntity.ContainsKey(JobLockEntityProperties.JobMessageId)))
                 {
-                    foreach (var jobLockEntity in jobLockEntities.Where(jobLockEntity => !jobLockEntity.ContainsKey(JobLockEntityProperties.JobMessageId)))
+                    foreach (TableEntity jobLockEntity in jobLockEntities.Where(jobLockEntity => !jobLockEntity.ContainsKey(JobLockEntityProperties.JobMessageId)))
                     {
-                        var response = await _azureJobMessageQueueClient.SendMessageAsync(
+                        Response<SendReceipt>? response = await _azureJobMessageQueueClient.SendMessageAsync(
                             new JobMessage(jobLockEntity.PartitionKey, jobLockEntity.GetString(JobLockEntityProperties.JobInfoEntityRowKey), jobLockEntity.RowKey).ToString(),
                             cancellationToken);
 
@@ -235,7 +235,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                     // 2. two jobs both send message, while only one job update entity successfully
                     try
                     {
-                        var transactionUpdateActions = jobLockEntities.Select(jobLockEntity =>
+                        IEnumerable<TableTransactionAction> transactionUpdateActions = jobLockEntities.Select(jobLockEntity =>
                             new TableTransactionAction(TableTransactionActionType.UpdateReplace, jobLockEntity, jobLockEntity.ETag));
 
                         _ = await _azureJobInfoTableClient.SubmitTransactionAsync(transactionUpdateActions, cancellationToken);
@@ -264,11 +264,11 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             _logger.LogInformation("Start to dequeue.");
 
             // step 1: receive message from message queue
-            var visibilityTimeout =
+            TimeSpan visibilityTimeout =
                 TimeSpan.FromSeconds(heartbeatTimeoutSec <= 0
                     ? DefaultVisibilityTimeoutInSeconds
                     : heartbeatTimeoutSec);
-            var message = (await _azureJobMessageQueueClient.ReceiveMessageAsync(visibilityTimeout, cancellationToken)).Value;
+            QueueMessage? message = (await _azureJobMessageQueueClient.ReceiveMessageAsync(visibilityTimeout, cancellationToken)).Value;
 
             if (message == null)
             {
@@ -276,7 +276,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                 return null;
             }
 
-            var jobMessage = JobMessage.Parse(message.Body.ToString());
+            JobMessage? jobMessage = JobMessage.Parse(message.Body.ToString());
 
             if (jobMessage == null)
             {
@@ -285,7 +285,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             }
 
             // step 2: get jobInfo entity and job lock entity
-            var (jobInfoEntity, jobLockEntity) = await AcquireJobEntityByRowKeysAsync(jobMessage.PartitionKey, new List<string> { jobMessage.RowKey, jobMessage.LockRowKey }, cancellationToken);
+            (TableEntity jobInfoEntity, TableEntity jobLockEntity) = await AcquireJobEntityByRowKeysAsync(jobMessage.PartitionKey, new List<string> { jobMessage.RowKey, jobMessage.LockRowKey }, cancellationToken);
             var jobInfo = jobInfoEntity.ToJobInfo<TJobInfo>();
 
             // step 3: check job status
@@ -354,17 +354,17 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             _logger.LogInformation($"Start to get job {jobId}.");
 
             // step 1: get job reverse index entity
-            var jobReverseIndexEntity = await GetJobReverseIndexEntityByIdAsync(queueType, jobId, cancellationToken);
+            JobReverseIndexEntity jobReverseIndexEntity = await GetJobReverseIndexEntityByIdAsync(queueType, jobId, cancellationToken);
 
             // step 2: get job info entity
-            var selectedProperties = returnDefinition ? null : SelectPropertiesExceptDefinition();
+            IEnumerable<string>? selectedProperties = returnDefinition ? null : SelectPropertiesExceptDefinition();
 
-            var jobInfoEntityResponse = await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(
+            Response<TableEntity>? jobInfoEntityResponse = await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(
                 jobReverseIndexEntity.JobInfoEntityPartitionKey,
                 jobReverseIndexEntity.JobInfoEntityRowKey,
                 selectedProperties,
                 cancellationToken);
-            var jobInfoEntity = jobInfoEntityResponse.Value;
+            TableEntity? jobInfoEntity = jobInfoEntityResponse.Value;
 
             // step 3: convert to job info.
             var jobInfo = jobInfoEntity.ToJobInfo<TJobInfo>();
@@ -377,12 +377,12 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
         {
             _logger.LogInformation($"Start to get jobs {string.Join(",", jobIds)}.");
 
-            var result = new ConcurrentBag<JobInfo>();
+            ConcurrentBag<JobInfo> result = new ConcurrentBag<JobInfo>();
 
             // https://docs.microsoft.com/en-us/dotnet/api/system.threading.semaphoreslim?view=net-6.0
             using (var throttler = new SemaphoreSlim(MaxThreadsCountForGettingJob, MaxThreadsCountForGettingJob))
             {
-                var tasks = jobIds.Select(async id =>
+                IEnumerable<Task> tasks = jobIds.Select(async id =>
                 {
                     await throttler.WaitAsync(cancellationToken).ConfigureAwait(false);
                     try
@@ -406,16 +406,16 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
         {
             _logger.LogInformation($"Start to get jobs in group {groupId}.");
 
-            var jobs = new List<JobInfo>();
+            List<JobInfo> jobs = new List<JobInfo>();
 
             // job lock entity has the same partition key, so we need to query the row key here
-            var selectedProperties = returnDefinition ? null : SelectPropertiesExceptDefinition();
+            IEnumerable<string>? selectedProperties = returnDefinition ? null : SelectPropertiesExceptDefinition();
 
-            var queryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
+            AsyncPageable<TableEntity>? queryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
                 filter: FilterJobInfosByGroupId(queueType, groupId),
                 select: selectedProperties,
                 cancellationToken: cancellationToken);
-            await foreach (var pageResult in queryResult.AsPages().WithCancellation(cancellationToken))
+            await foreach (Page<TableEntity> pageResult in queryResult.AsPages().WithCancellation(cancellationToken))
             {
                 jobs.AddRange(pageResult.Values.Select(entity => entity.ToJobInfo<TJobInfo>()));
             }
@@ -429,7 +429,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             _logger.LogInformation($"Start to keep alive for job {jobInfo.Id}.");
 
             // step 1: get jobInfo entity and job lock entity
-            var (jobInfoEntity, jobLockEntity) = await AcquireJobEntityByJobInfoAsync(jobInfo, cancellationToken);
+            (TableEntity jobInfoEntity, TableEntity jobLockEntity) = await AcquireJobEntityByJobInfoAsync(jobInfo, cancellationToken);
 
             // step 2: check version
             // the version is assigned when dequeue,
@@ -445,7 +445,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             Response<UpdateReceipt>? response = null;
             try
             {
-                var visibilityTimeout = TimeSpan.FromSeconds((long)jobInfoEntity[JobInfoEntityProperties.HeartbeatTimeoutSec] <= 0
+                TimeSpan visibilityTimeout = TimeSpan.FromSeconds((long)jobInfoEntity[JobInfoEntityProperties.HeartbeatTimeoutSec] <= 0
                     ? DefaultVisibilityTimeoutInSeconds
                     : (long)jobInfoEntity[JobInfoEntityProperties.HeartbeatTimeoutSec]);
                 response = await _azureJobMessageQueueClient.UpdateMessageAsync(
@@ -500,7 +500,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             }
 
             // step 8: check if cancel requested
-            var shouldCancel = (await GetJobByIdAsync(jobInfo.QueueType, jobInfo.Id, false, cancellationToken)).CancelRequested;
+            bool shouldCancel = (await GetJobByIdAsync(jobInfo.QueueType, jobInfo.Id, false, cancellationToken)).CancelRequested;
 
             _logger.LogInformation($"Keep alive for job {jobInfo.Id} successfully.");
 
@@ -511,15 +511,15 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
         {
             _logger.LogInformation($"Start to cancel jobs in group {groupId}.");
 
-            var jobInfoEntities = new List<TableEntity>();
+            List<TableEntity> jobInfoEntities = new List<TableEntity>();
 
             // step 1: query all job ids in a group, using range query for row key to ignore lock/index entities in same partition
-            var queryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
+            AsyncPageable<TableEntity>? queryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
                 filter: FilterJobInfosByGroupId(queueType, groupId),
                 cancellationToken: cancellationToken);
-            await foreach (var pageResult in queryResult.AsPages().WithCancellation(cancellationToken))
+            await foreach (Page<TableEntity> pageResult in queryResult.AsPages().WithCancellation(cancellationToken))
             {
-                foreach (var jobInfoEntity in pageResult.Values)
+                foreach (TableEntity? jobInfoEntity in pageResult.Values)
                 {
                     // step 2: cancel job.
                     CancelJobInternal(jobInfoEntity);
@@ -528,16 +528,16 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             }
 
             // step 3: transaction update the cancelled jobs.
-            var transactionActions = jobInfoEntities.Select(entity =>
+            IEnumerable<TableTransactionAction> transactionActions = jobInfoEntities.Select(entity =>
                 new TableTransactionAction(TableTransactionActionType.UpdateReplace, entity, entity.ETag));
 
-            var responseList = await _azureJobInfoTableClient.SubmitTransactionAsync(transactionActions, cancellationToken);
-            var batchFailed = responseList.Value.Any(response => response.IsError);
+            Response<IReadOnlyList<Response>>? responseList = await _azureJobInfoTableClient.SubmitTransactionAsync(transactionActions, cancellationToken);
+            bool batchFailed = responseList.Value.Any(response => response.IsError);
 
             // step 4: log error and throw exceptions for failure
             if (batchFailed)
             {
-                var errorMessage = responseList.Value.Where(response => response.IsError).Select(response => response.ReasonPhrase).First();
+                string errorMessage = responseList.Value.Where(response => response.IsError).Select(response => response.ReasonPhrase).First();
                 _logger.LogError($"Failed to cancel jobs in group {groupId}. Reason: {errorMessage}");
                 throw new JobManagementException($"Failed to cancel jobs in group {groupId}. Reason: {errorMessage}");
             }
@@ -550,10 +550,10 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             _logger.LogInformation($"Start to cancel job {jobId}.");
 
             // step 1:Load reverse index entity.
-            var reverseIndexEntity = await GetJobReverseIndexEntityByIdAsync(queueType, jobId, cancellationToken);
+            JobReverseIndexEntity reverseIndexEntity = await GetJobReverseIndexEntityByIdAsync(queueType, jobId, cancellationToken);
 
             // step 2: get jobInfo entity
-            var jobInfoEntity = (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(reverseIndexEntity.JobInfoEntityPartitionKey, reverseIndexEntity.JobInfoEntityRowKey, cancellationToken: cancellationToken)).Value;
+            TableEntity? jobInfoEntity = (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(reverseIndexEntity.JobInfoEntityPartitionKey, reverseIndexEntity.JobInfoEntityRowKey, cancellationToken: cancellationToken)).Value;
 
             // step 3: cancel job
             CancelJobInternal(jobInfoEntity);
@@ -569,7 +569,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             _logger.LogInformation($"Start to complete job {jobInfo.Id}.");
 
             // step 1: get jobInfo entity and job lock entity
-            var (retrievedJobInfoEntity, jobLockEntity) = await AcquireJobEntityByJobInfoAsync(jobInfo, cancellationToken);
+            (TableEntity retrievedJobInfoEntity, TableEntity jobLockEntity) = await AcquireJobEntityByJobInfoAsync(jobInfo, cancellationToken);
 
             // step 2: check version
             if ((long)retrievedJobInfoEntity[JobInfoEntityProperties.Version] != jobInfo.Version)
@@ -579,7 +579,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             }
 
             // step 3: get shouldCancel
-            var shouldCancel = (bool)retrievedJobInfoEntity[JobInfoEntityProperties.CancelRequested];
+            bool shouldCancel = (bool)retrievedJobInfoEntity[JobInfoEntityProperties.CancelRequested];
 
             // step 4: update status
             // Reference: https://github.com/microsoft/fhir-server/blob/e1117009b6db995672cc4d31457cb3e6f32e19a3/src/Microsoft.Health.Fhir.SqlServer/Features/Schema/Sql/Sprocs/PutJobStatus.sql#L16
@@ -657,12 +657,12 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
         /// <returns>The job ids, throw exceptions if fails.</returns>
         private async Task<List<long>> GetIncrementalJobIds(byte queueType, int count, CancellationToken cancellationToken)
         {
-            var partitionKey = AzureStorageKeyProvider.JobIdPartitionKey(queueType);
-            var rowKey = AzureStorageKeyProvider.JobIdRowKey(queueType);
+            string partitionKey = AzureStorageKeyProvider.JobIdPartitionKey(queueType);
+            string rowKey = AzureStorageKeyProvider.JobIdRowKey(queueType);
             JobIdEntity entity;
             try
             {
-                var response = await _azureJobInfoTableClient.GetEntityAsync<JobIdEntity>(partitionKey, rowKey, cancellationToken: cancellationToken);
+                Response<JobIdEntity>? response = await _azureJobInfoTableClient.GetEntityAsync<JobIdEntity>(partitionKey, rowKey, cancellationToken: cancellationToken);
                 entity = response.Value;
             }
             catch (RequestFailedException ex) when (IsSpecifiedErrorCode(ex, AzureStorageErrorCode.GetEntityNotFoundErrorCode))
@@ -690,9 +690,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                 entity = (await _azureJobInfoTableClient.GetEntityAsync<JobIdEntity>(partitionKey, rowKey, cancellationToken: cancellationToken)).Value;
             }
 
-            var result = new List<long>();
+            List<long> result = new List<long>();
 
-            for (var i = 0; i < count; i++)
+            for (int i = 0; i < count; i++)
             {
                 result.Add(entity.NextJobId);
                 entity.NextJobId++;
@@ -715,9 +715,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
 
         private async Task<JobReverseIndexEntity> GetJobReverseIndexEntityByIdAsync(byte queueType, long jobId, CancellationToken cancellationToken)
         {
-            var reversePartitionKey = AzureStorageKeyProvider.JobReverseIndexPartitionKey(queueType, jobId);
-            var reverseRowKey = AzureStorageKeyProvider.JobReverseIndexRowKey(queueType, jobId);
-            var reverseIndexResponse = await _azureJobInfoTableClient.GetEntityAsync<JobReverseIndexEntity>(reversePartitionKey, reverseRowKey, cancellationToken: cancellationToken);
+            string reversePartitionKey = AzureStorageKeyProvider.JobReverseIndexPartitionKey(queueType, jobId);
+            string reverseRowKey = AzureStorageKeyProvider.JobReverseIndexRowKey(queueType, jobId);
+            Response<JobReverseIndexEntity>? reverseIndexResponse = await _azureJobInfoTableClient.GetEntityAsync<JobReverseIndexEntity>(reversePartitionKey, reverseRowKey, cancellationToken: cancellationToken);
             return reverseIndexResponse.Value;
         }
 
@@ -727,8 +727,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
         {
             EnsureArg.IsNotNull(jobInfo, nameof(jobInfo));
 
-            var pk = AzureStorageKeyProvider.JobInfoPartitionKey(jobInfo.QueueType, jobInfo.GroupId);
-            var rks = new List<string>
+            string pk = AzureStorageKeyProvider.JobInfoPartitionKey(jobInfo.QueueType, jobInfo.GroupId);
+            List<string> rks = new List<string>
             {
                 AzureStorageKeyProvider.JobLockRowKey(((TJobInfo)jobInfo).JobIdentifier()),
                 AzureStorageKeyProvider.JobInfoRowKey(jobInfo.GroupId, jobInfo.Id),
@@ -742,14 +742,14 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
             List<string> rks,
             CancellationToken cancellationToken)
         {
-            var jobEntityQueryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
+            AsyncPageable<TableEntity>? jobEntityQueryResult = _azureJobInfoTableClient.QueryAsync<TableEntity>(
                 filter: TransactionGetByKeys(pk, rks),
                 cancellationToken: cancellationToken);
 
-            var retrievedJobInfoEntities = new List<TableEntity>();
-            var retrievedJobLockEntities = new List<TableEntity>();
+            List<TableEntity> retrievedJobInfoEntities = new List<TableEntity>();
+            List<TableEntity> retrievedJobLockEntities = new List<TableEntity>();
 
-            await foreach (var pageResult in jobEntityQueryResult.AsPages().WithCancellation(cancellationToken))
+            await foreach (Page<TableEntity> pageResult in jobEntityQueryResult.AsPages().WithCancellation(cancellationToken))
             {
                 retrievedJobInfoEntities.AddRange(pageResult.Values.Where(entity => entity.ContainsKey(JobInfoEntityProperties.Id)));
                 retrievedJobLockEntities.AddRange(pageResult.Values.Where(entity => !entity.ContainsKey(JobInfoEntityProperties.Id)));
@@ -780,7 +780,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement
                 throw new JobManagementException("Failed to get JobInfoEntity properties, the type is null.");
             }
 
-            var tableEntityProperties = new[] { "PartitionKey", "RowKey", "Timestamp", "ETag" };
+            string[] tableEntityProperties = new[] { "PartitionKey", "RowKey", "Timestamp", "ETag" };
             return tableEntityProperties.Concat(type.GetFields().Select(p => p.Name).Except(new List<string> { JobInfoEntityProperties.Definition }));
         }
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/JobInfoExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/JobInfoExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.Extensions
         {
             string? partitionKey = AzureStorageKeyProvider.JobInfoPartitionKey(jobInfo.QueueType, jobInfo.GroupId);
             string? rowKey = AzureStorageKeyProvider.JobInfoRowKey(jobInfo.GroupId, jobInfo.Id);
-            var jobInfoEntity = new TableEntity(partitionKey, rowKey)
+            TableEntity jobInfoEntity = new TableEntity(partitionKey, rowKey)
             {
                 { JobInfoEntityProperties.Id, jobInfo.Id },
                 { JobInfoEntityProperties.QueueType, (int)jobInfo.QueueType },
@@ -54,7 +54,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.Extensions
         public static TJobInfo ToJobInfo<TJobInfo>(this TableEntity entity)
             where TJobInfo : AzureStorageJobInfo, new()
         {
-            var jobInfo = new TJobInfo
+            TJobInfo jobInfo = new TJobInfo
             {
                 Id = (long)entity[JobInfoEntityProperties.Id],
                 QueueType = Convert.ToByte(entity[JobInfoEntityProperties.QueueType]),

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/JobInfoExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/JobInfoExtensions.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.Extensions
         public static TableEntity ToTableEntity<TJobInfo>(this TJobInfo jobInfo)
             where TJobInfo : AzureStorageJobInfo, new()
         {
-            var partitionKey = AzureStorageKeyProvider.JobInfoPartitionKey(jobInfo.QueueType, jobInfo.GroupId);
-            var rowKey = AzureStorageKeyProvider.JobInfoRowKey(jobInfo.GroupId, jobInfo.Id);
+            string? partitionKey = AzureStorageKeyProvider.JobInfoPartitionKey(jobInfo.QueueType, jobInfo.GroupId);
+            string? rowKey = AzureStorageKeyProvider.JobInfoRowKey(jobInfo.GroupId, jobInfo.Id);
             var jobInfoEntity = new TableEntity(partitionKey, rowKey)
             {
                 { JobInfoEntityProperties.Id, jobInfo.Id },

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/StringExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/StringExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.Extensions
 
             using (var hash = SHA256.Create())
             {
-                byte[] ? result = hash.ComputeHash(Encoding.UTF8.GetBytes(input));
+                byte[] result = hash.ComputeHash(Encoding.UTF8.GetBytes(input));
                 foreach (byte b in result)
                 {
                     sb.Append(b.ToString("x2"));

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/StringExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/StringExtensions.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.Extensions
 
             using (var hash = SHA256.Create())
             {
-                var result = hash.ComputeHash(Encoding.UTF8.GetBytes(input));
-                foreach (var b in result)
+                byte[]? result = hash.ComputeHash(Encoding.UTF8.GetBytes(input));
+                foreach (byte b in result)
                 {
                     sb.Append(b.ToString("x2"));
                 }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/StringExtensions.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.JobManagement/Extensions/StringExtensions.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.Extensions
                 return input;
             }
 
-            var sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder();
 
-            using (var hash = SHA256.Create())
+            using (SHA256 hash = SHA256.Create())
             {
                 byte[]? result = hash.ComputeHash(Encoding.UTF8.GetBytes(input));
                 foreach (byte b in result)

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryAccessTokenProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryAccessTokenProvider.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
             var registryUri = new Uri($"https://{registryServer}");
             var exchangeUri = new Uri(registryUri, ExchangeAcrRefreshTokenUrl);
 
-            var parameters = new List<KeyValuePair<string, string>>();
+            List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>();
             parameters.Add(new KeyValuePair<string, string>("grant_type", "access_token"));
             parameters.Add(new KeyValuePair<string, string>("service", registryUri.Host));
             parameters.Add(new KeyValuePair<string, string>("access_token", aadToken));
@@ -120,7 +120,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
                 Content = new FormUrlEncodedContent(parameters),
             };
 
-            var refreshTokenResponse = await SendRequestAsync(request, cancellationToken);
+            HttpResponseMessage refreshTokenResponse = await SendRequestAsync(request, cancellationToken);
             if (!refreshTokenResponse.IsSuccessStatusCode)
             {
                 switch (refreshTokenResponse.StatusCode)
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
                 }
             }
 
-            var refreshTokenText = await refreshTokenResponse.Content.ReadAsStringAsync(cancellationToken);
+            string refreshTokenText = await refreshTokenResponse.Content.ReadAsStringAsync(cancellationToken);
             dynamic refreshTokenJson = JsonConvert.DeserializeObject(refreshTokenText);
             string refreshToken = (string)refreshTokenJson.refresh_token;
             if (string.IsNullOrEmpty(refreshToken))
@@ -159,7 +159,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
             var registryUri = new Uri($"https://{registryServer}");
             var accessTokenUri = new Uri(registryUri, GetAcrAccessTokenUrl);
 
-            var parameters = new List<KeyValuePair<string, string>>();
+            List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>();
             parameters.Add(new KeyValuePair<string, string>("grant_type", "refresh_token"));
             parameters.Add(new KeyValuePair<string, string>("service", registryUri.Host));
             parameters.Add(new KeyValuePair<string, string>("refresh_token", refreshToken));
@@ -171,7 +171,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
                 Content = new FormUrlEncodedContent(parameters),
             };
 
-            var accessTokenResponse = await SendRequestAsync(request, cancellationToken);
+            HttpResponseMessage accessTokenResponse = await SendRequestAsync(request, cancellationToken);
             if (!accessTokenResponse.IsSuccessStatusCode)
             {
                 switch (accessTokenResponse.StatusCode)
@@ -191,7 +191,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
                 }
             }
 
-            var accessTokenText = await accessTokenResponse.Content.ReadAsStringAsync(cancellationToken);
+            string accessTokenText = await accessTokenResponse.Content.ReadAsStringAsync(cancellationToken);
             dynamic accessTokenJson = JsonConvert.DeserializeObject(accessTokenText);
             string accessToken = accessTokenJson.access_token;
             if (string.IsNullOrEmpty(accessToken))

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryAccessTokenProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryAccessTokenProvider.cs
@@ -108,14 +108,14 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
 
         private async Task<string> ExchangeAcrRefreshToken(string registryServer, string aadToken, CancellationToken cancellationToken)
         {
-            var registryUri = new Uri($"https://{registryServer}");
-            var exchangeUri = new Uri(registryUri, ExchangeAcrRefreshTokenUrl);
+            Uri registryUri = new Uri($"https://{registryServer}");
+            Uri exchangeUri = new Uri(registryUri, ExchangeAcrRefreshTokenUrl);
 
             List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>();
             parameters.Add(new KeyValuePair<string, string>("grant_type", "access_token"));
             parameters.Add(new KeyValuePair<string, string>("service", registryUri.Host));
             parameters.Add(new KeyValuePair<string, string>("access_token", aadToken));
-            using var request = new HttpRequestMessage(HttpMethod.Post, exchangeUri)
+            using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, exchangeUri)
             {
                 Content = new FormUrlEncodedContent(parameters),
             };
@@ -156,8 +156,8 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
 
         private async Task<string> GetAcrAccessToken(string registryServer, string refreshToken, CancellationToken cancellationToken)
         {
-            var registryUri = new Uri($"https://{registryServer}");
-            var accessTokenUri = new Uri(registryUri, GetAcrAccessTokenUrl);
+            Uri registryUri = new Uri($"https://{registryServer}");
+            Uri accessTokenUri = new Uri(registryUri, GetAcrAccessTokenUrl);
 
             List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>();
             parameters.Add(new KeyValuePair<string, string>("grant_type", "refresh_token"));
@@ -166,7 +166,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
 
             // Add scope for AcrPull role (granted at registry level).
             parameters.Add(new KeyValuePair<string, string>("scope", "repository:*:pull"));
-            using var request = new HttpRequestMessage(HttpMethod.Post, accessTokenUri)
+            using HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, accessTokenUri)
             {
                 Content = new FormUrlEncodedContent(parameters),
             };

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryTemplateProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryTemplateProvider.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
             _diagnosticLogger = diagnosticLogger;
             _logger = logger;
 
-            var templateCollectionCache = new MemoryCache(new MemoryCacheOptions() { SizeLimit = 100000000 });
-            var config = new TemplateCollectionConfiguration();
+            MemoryCache templateCollectionCache = new MemoryCache(new MemoryCacheOptions() { SizeLimit = 100000000 });
+            TemplateCollectionConfiguration config = new TemplateCollectionConfiguration();
             _templateCollectionProviderFactory = new TemplateCollectionProviderFactory(templateCollectionCache, Options.Create(config));
         }
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryTemplateProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryTemplateProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Logging;
 using Microsoft.Health.Fhir.Synapse.SchemaManagement.Exceptions;
 using Microsoft.Health.Fhir.TemplateManagement;
+using Microsoft.Health.Fhir.TemplateManagement.ArtifactProviders;
 using Microsoft.Health.Fhir.TemplateManagement.Exceptions;
 using Microsoft.Health.Fhir.TemplateManagement.Models;
 using Polly;
@@ -62,11 +63,11 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
                 throw new ContainerRegistrySchemaException(string.Format("Failed to parse the schema image reference {0} to image information. Reason: {1}.", schemaImageReference, ex.Message), ex);
             }
 
-            var accessToken = await _containerRegistryTokenProvider.GetTokenAsync(imageInfo.Registry, cancellationToken);
+            string accessToken = await _containerRegistryTokenProvider.GetTokenAsync(imageInfo.Registry, cancellationToken);
 
             try
             {
-                var provider = _templateCollectionProviderFactory.CreateTemplateCollectionProvider(schemaImageReference, accessToken);
+                ITemplateCollectionProvider provider = _templateCollectionProviderFactory.CreateTemplateCollectionProvider(schemaImageReference, accessToken);
 
                 // "TemplateManagementException" is base exception for "ContainerRegistryAuthenticationException" and "ImageFetchException"
                 return await Policy

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/FhirParquetSchemaManager.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/FhirParquetSchemaManager.cs
@@ -107,18 +107,18 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet
 
         private Dictionary<string, FhirParquetSchemaNode> LoadSchemaMap()
         {
-            var defaultSchemaProvider = _schemaProviderDelegate(FhirParquetSchemaConstants.DefaultSchemaProviderKey);
+            IParquetSchemaProvider defaultSchemaProvider = _schemaProviderDelegate(FhirParquetSchemaConstants.DefaultSchemaProviderKey);
 
             // Get default schema, the default schema keys are resource types, like "Patient", "Encounter".
-            var resourceSchemaNodesMap = defaultSchemaProvider.GetSchemasAsync().Result;
+            Dictionary<string, FhirParquetSchemaNode> resourceSchemaNodesMap = defaultSchemaProvider.GetSchemasAsync().Result;
             _logger.LogInformation($"{resourceSchemaNodesMap.Count} resource default schemas have been loaded.");
 
             if (_enableCustomizedSchema)
             {
-                var customizedSchemaProvider = _schemaProviderDelegate(FhirParquetSchemaConstants.CustomSchemaProviderKey);
+                IParquetSchemaProvider customizedSchemaProvider = _schemaProviderDelegate(FhirParquetSchemaConstants.CustomSchemaProviderKey);
 
                 // Get customized schema, the customized schema keys are resource types with "_customized" suffix, like "Patient_Customized", "Encounter_Customized".
-                var resourceCustomizedSchemaNodesMap = customizedSchemaProvider.GetSchemasAsync().Result;
+                Dictionary<string, FhirParquetSchemaNode> resourceCustomizedSchemaNodesMap = customizedSchemaProvider.GetSchemasAsync().Result;
 
                 _logger.LogInformation($"{resourceCustomizedSchemaNodesMap.Count} resource customized schemas have been loaded.");
                 resourceSchemaNodesMap = resourceSchemaNodesMap.Concat(resourceCustomizedSchemaNodesMap).ToDictionary(x => x.Key, x => x.Value);
@@ -129,11 +129,11 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet
 
         private static Dictionary<string, List<string>> LoadSchemaTypeMap(Dictionary<string, FhirParquetSchemaNode> schemaMap)
         {
-            var schemaTypesMap = new Dictionary<string, List<string>>();
+            Dictionary<string, List<string>> schemaTypesMap = new Dictionary<string, List<string>>();
 
             // Each resource type may map to multiple output schema types
             // E.g: Schema type list for "Patient" resource can be ["Patient", "Patient_Customized"]
-            foreach (var schemaNodeItem in schemaMap)
+            foreach (KeyValuePair<string, FhirParquetSchemaNode> schemaNodeItem in schemaMap)
             {
                 if (schemaTypesMap.ContainsKey(schemaNodeItem.Value.Type))
                 {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/AcrCustomizedSchemaProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/AcrCustomizedSchemaProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DotLiquid;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Liquid.Converter.Models.Json;
@@ -40,7 +41,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
 
         public async Task<Dictionary<string, FhirParquetSchemaNode>> GetSchemasAsync(CancellationToken cancellationToken = default)
         {
-            var jsonSchemaCollection = await GetJsonSchemaCollectionAsync(cancellationToken);
+            Dictionary<string, JsonSchema> jsonSchemaCollection = await GetJsonSchemaCollectionAsync(cancellationToken);
 
             return jsonSchemaCollection
                 .Select(x => JsonSchemaParser.ParseJSchema(x.Key, x.Value))
@@ -49,7 +50,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
 
         private async Task<Dictionary<string, JsonSchema>> GetJsonSchemaCollectionAsync(CancellationToken cancellationToken)
         {
-            var result = new Dictionary<string, JsonSchema>();
+            Dictionary<string, JsonSchema> result = new Dictionary<string, JsonSchema>();
 
             if (string.IsNullOrWhiteSpace(_schemaImageReference))
             {
@@ -58,15 +59,15 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
                 throw new ContainerRegistrySchemaException("Schema image reference is null or empty.");
             }
 
-            var templateCollections = await _containerRegistryTemplateProvider.GetTemplateCollectionAsync(_schemaImageReference, cancellationToken);
+            List<Dictionary<string, Template>> templateCollections = await _containerRegistryTemplateProvider.GetTemplateCollectionAsync(_schemaImageReference, cancellationToken);
 
             // Fetch all files with suffix ".schema.json" as Json schema template.
             // All Json schema files should be in "Schema" directory under the root path of the image.
-            foreach (var templates in templateCollections)
+            foreach (Dictionary<string, Template> templates in templateCollections)
             {
-                foreach (var templateItem in templates)
+                foreach (KeyValuePair<string, Template> templateItem in templates)
                 {
-                    var templatePathSegments = templateItem.Key.Split('/');
+                    string[] templatePathSegments = templateItem.Key.Split('/');
 
                     if (!string.Equals(templatePathSegments[0], FhirParquetSchemaConstants.JsonSchemaTemplateDirectory, StringComparison.InvariantCultureIgnoreCase))
                     {
@@ -87,7 +88,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
                     else
                     {
                         // The customized schema keys are like "Patient_Customized", "Observation_Customized"...
-                        var resourceType = templatePathSegments[1].Substring(0, templatePathSegments[1].Length - FhirParquetSchemaConstants.JsonSchemaTemplateFileExtension.Length);
+                        string resourceType = templatePathSegments[1].Substring(0, templatePathSegments[1].Length - FhirParquetSchemaConstants.JsonSchemaTemplateFileExtension.Length);
 
                         if (!(templateItem.Value.Root is JSchemaDocument customizedSchemaDocument) || customizedSchemaDocument.Schema == null)
                         {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/JsonSchemaParser.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/JsonSchemaParser.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
                 throw new GenerateFhirParquetSchemaNodeException(string.Format("The \"{0}\" customized schema type \"{1}\" should be \"object\".", resourceType, jsonSchema.Type));
             }
 
-            var fhirPath = new List<string>() { resourceType };
+            List<string> fhirPath = new List<string>() { resourceType };
 
             var customizedSchemaNode = new FhirParquetSchemaNode()
             {
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
                 SubNodes = new Dictionary<string, FhirParquetSchemaNode>(),
             };
 
-            foreach (var property in jsonSchema.Properties)
+            foreach (KeyValuePair<string, JsonSchemaProperty> property in jsonSchema.Properties)
             {
                 fhirPath.Add(property.Key);
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/JsonSchemaParser.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/JsonSchemaParser.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
 
             List<string> fhirPath = new List<string>() { resourceType };
 
-            var customizedSchemaNode = new FhirParquetSchemaNode()
+            FhirParquetSchemaNode customizedSchemaNode = new FhirParquetSchemaNode()
             {
                 Name = resourceType,
                 Type = resourceType,

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/LocalDefaultSchemaProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/LocalDefaultSchemaProvider.cs
@@ -72,12 +72,12 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
 
             var executingAssembly = Assembly.GetExecutingAssembly();
             string folderName = GetEmbeddedSchemaFolder(executingAssembly, fhirVersion);
-            var resourceNames = executingAssembly
+            string[] resourceNames = executingAssembly
                 .GetManifestResourceNames()
                 .Where(r => r.StartsWith(folderName) && r.EndsWith(".json"))
                 .ToArray();
 
-            foreach (var name in resourceNames)
+            foreach (string name in resourceNames)
             {
                 using (Stream stream = executingAssembly.GetManifestResourceStream(name))
                 using (StreamReader reader = new StreamReader(stream))

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/LocalDefaultSchemaProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/Parquet/SchemaProvider/LocalDefaultSchemaProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
             {
                 defaultSchemaNodesMap = embeddedSchemas.Select(schemaItem =>
                 {
-                    var schemaNode = JsonConvert.DeserializeObject<FhirParquetSchemaNode>(schemaItem.Value);
+                    FhirParquetSchemaNode schemaNode = JsonConvert.DeserializeObject<FhirParquetSchemaNode>(schemaItem.Value);
                     return new KeyValuePair<string, FhirParquetSchemaNode>(schemaNode.Type, schemaNode);
                 }).ToDictionary(x => x.Key, x => x.Value);
             }
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider
         {
             Dictionary<string, string> embeddedSchema = new Dictionary<string, string>();
 
-            var executingAssembly = Assembly.GetExecutingAssembly();
+            Assembly executingAssembly = Assembly.GetExecutingAssembly();
             string folderName = GetEmbeddedSchemaFolder(executingAssembly, fhirVersion);
             string[] resourceNames = executingAssembly
                 .GetManifestResourceNames()

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/Microsoft.Health.Fhir.Synapse.Tool.csproj
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/Microsoft.Health.Fhir.Synapse.Tool.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Health.Parquet" Version="$(ParquetNativeLibVersion)" />
+    <PackageReference Include="Microsoft.Health.Parquet" Version="1.0.0.215" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/Program.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/Program.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Synapse.Tool
     {
         public static async Task Main(string[] args)
         {
-            var host = CreateHostBuilder(args).Build();
+            IHost host = CreateHostBuilder(args).Build();
             await host.RunAsync();
         }
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Configurations/ConfigurationValidators/ValidatorUtilityTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Configurations/ConfigurationValidators/ValidatorUtilityTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations.ConfigurationValidators;
@@ -104,7 +105,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.UnitTests.Configurations.Configur
         [MemberData(nameof(GetValidTableOrQueueName))]
         public void GivenValidAgentName_WhenValidate_NoExceptionShouldBeThrown(string name)
         {
-            var exception = Record.Exception(() => ValidateUtility.ValidateQueueOrTableName(name));
+            Exception exception = Record.Exception(() => ValidateUtility.ValidateQueueOrTableName(name));
             Assert.Null(exception);
         }
 
@@ -119,7 +120,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.UnitTests.Configurations.Configur
         [MemberData(nameof(GetValidImageReference))]
         public void GivenValidImageReference_WhenValidate_NoExceptionShouldBeThrown(string imageReference)
         {
-            var exception = Record.Exception(() => ValidateUtility.ValidateImageReference(imageReference));
+            Exception exception = Record.Exception(() => ValidateUtility.ValidateImageReference(imageReference));
             Assert.Null(exception);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Configurations/ConfigurationValidators/ValidatorUtilityTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Configurations/ConfigurationValidators/ValidatorUtilityTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.UnitTests.Configurations.Configur
         [Fact]
         public void GivenInvalidFilterConfiguration_WhenValidate_ExceptionShouldBeThrown()
         {
-            var config = new FilterConfiguration()
+            FilterConfiguration config = new FilterConfiguration()
             {
                 FilterScope = FilterScope.Group,
                 GroupId = string.Empty,

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Extensions/ConfigurationRegistrationExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Extensions/ConfigurationRegistrationExtensionsTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,7 +52,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.UnitTests.Extensions
         [MemberData(nameof(GetInvalidServiceConfiguration))]
         public void GivenInvalidServiceCollectionConfiguration_WhenValidate_ExceptionShouldBeThrown(string configKey, string configValue, string expectedMessageStart)
         {
-            var config = new Dictionary<string, string>(TestValidConfiguration);
+            Dictionary<string, string> config = new Dictionary<string, string>(TestValidConfiguration);
             config[configKey] = configValue;
 
             var builder = new ConfigurationBuilder();
@@ -67,10 +68,10 @@ namespace Microsoft.Health.Fhir.Synapse.Common.UnitTests.Extensions
         {
             var builder = new ConfigurationBuilder();
             builder.AddInMemoryCollection(TestValidConfiguration);
-            var config = builder.Build();
+            IConfigurationRoot config = builder.Build();
 
             var serviceCollection = new ServiceCollection();
-            var exception = Record.Exception(() => serviceCollection.AddConfiguration(config));
+            Exception exception = Record.Exception(() => serviceCollection.AddConfiguration(config));
             Assert.Null(exception);
         }
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Extensions/ConfigurationRegistrationExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Common.UnitTests/Extensions/ConfigurationRegistrationExtensionsTests.cs
@@ -55,22 +55,22 @@ namespace Microsoft.Health.Fhir.Synapse.Common.UnitTests.Extensions
             Dictionary<string, string> config = new Dictionary<string, string>(TestValidConfiguration);
             config[configKey] = configValue;
 
-            var builder = new ConfigurationBuilder();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
             builder.AddInMemoryCollection(config);
-            var serviceCollection = new ServiceCollection();
+            ServiceCollection serviceCollection = new ServiceCollection();
 
-            var exception = Assert.Throws<ConfigurationErrorException>(() => serviceCollection.AddConfiguration(builder.Build()));
+            ConfigurationErrorException exception = Assert.Throws<ConfigurationErrorException>(() => serviceCollection.AddConfiguration(builder.Build()));
             Assert.StartsWith(expectedMessageStart, exception.Message);
         }
 
         [Fact]
         public void GivenValidServiceCollectionConfiguration_WhenValidate_NoExceptionShouldBeThrown()
         {
-            var builder = new ConfigurationBuilder();
+            ConfigurationBuilder builder = new ConfigurationBuilder();
             builder.AddInMemoryCollection(TestValidConfiguration);
             IConfigurationRoot config = builder.Build();
 
-            var serviceCollection = new ServiceCollection();
+            ServiceCollection serviceCollection = new ServiceCollection();
             Exception exception = Record.Exception(() => serviceCollection.AddConfiguration(config));
             Assert.Null(exception);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/ContainerRegistryTestUtils.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/ContainerRegistryTestUtils.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
 
         public static IContainerRegistryTokenProvider GetMockAcrTokenProvider(string accessToken)
         {
-            var tokenProvider = Substitute.For<IContainerRegistryTokenProvider>();
+            IContainerRegistryTokenProvider tokenProvider = Substitute.For<IContainerRegistryTokenProvider>();
 
             tokenProvider.GetTokenAsync(default, default).ReturnsForAnyArgs($"Basic {accessToken}");
             return tokenProvider;
@@ -47,7 +47,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
 
             // Upload config blob
             byte[] originalConfigBytes = Encoding.UTF8.GetBytes(emptyConfigStr);
-            using var originalConfigStream = new MemoryStream(originalConfigBytes);
+            using MemoryStream originalConfigStream = new MemoryStream(originalConfigBytes);
             string originalConfigDigest = ComputeDigest(originalConfigStream);
             await UploadBlob(acrClient, originalConfigStream, imageInfo.ImageName, originalConfigDigest);
 
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
             layers.Add(new Descriptor("application/vnd.oci.image.layer.v1.tar", blobLength, blobDigest));
 
             // Push manifest
-            var v2Manifest = new V2Manifest(schemaV2, mediatypeV2Manifest, new Descriptor(mediatypeV1Manifest, originalConfigBytes.Length, originalConfigDigest), layers);
+            V2Manifest v2Manifest = new V2Manifest(schemaV2, mediatypeV2Manifest, new Descriptor(mediatypeV1Manifest, originalConfigBytes.Length, originalConfigDigest), layers);
             await acrClient.Manifests.CreateAsync(imageInfo.ImageName, imageInfo.Tag, v2Manifest);
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
             s.Position = 0;
             StringBuilder sb = new StringBuilder();
 
-            using (var hash = SHA256.Create())
+            using (SHA256 hash = SHA256.Create())
             {
                 byte[] result = hash.ComputeHash(s);
                 foreach (byte b in result)

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/ContainerRegistryTestUtils.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/ContainerRegistryTestUtils.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
             using FileStream fileStream = File.OpenRead(templateFilePath);
             using MemoryStream byteStream = new MemoryStream();
             fileStream.CopyTo(byteStream);
-            var blobLength = byteStream.Length;
+            long blobLength = byteStream.Length;
             string blobDigest = ComputeDigest(byteStream);
             await UploadBlob(acrClient, byteStream, imageInfo.ImageName, blobDigest);
             layers.Add(new Descriptor("application/vnd.oci.image.layer.v1.tar", blobLength, blobDigest));
@@ -70,8 +70,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
         private static async Task UploadBlob(AzureContainerRegistryClient acrClient, Stream stream, string repository, string digest)
         {
             stream.Position = 0;
-            var uploadInfo = await acrClient.Blob.StartUploadAsync(repository);
-            var uploadedLayer = await acrClient.Blob.UploadAsync(stream, uploadInfo.Location);
+            BlobStartUploadHeaders uploadInfo = await acrClient.Blob.StartUploadAsync(repository);
+            BlobUploadHeaders uploadedLayer = await acrClient.Blob.UploadAsync(stream, uploadInfo.Location);
             await acrClient.Blob.EndUploadAsync(digest, uploadedLayer.Location);
         }
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/ContainerRegistryFilterProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/ContainerRegistryFilterProviderTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
             ImageInfo imageInfo = ImageInfo.CreateFromImageReference(_testImageReference);
             await ContainerRegistryTestUtils.GenerateImageAsync(imageInfo, _testContainerRegistryAccessToken, TestUtils.TestFilterTarGzPath);
 
-            var containerRegistryFilterProvider = new ContainerRegistryFilterProvider(
+            ContainerRegistryFilterProvider containerRegistryFilterProvider = new ContainerRegistryFilterProvider(
                 Options.Create(new FilterLocation()
                 {
                     EnableExternalFilter = true,
@@ -72,7 +72,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         {
             Skip.If(_testImageReference == null);
 
-            var containerRegistryFilterProvider = new ContainerRegistryFilterProvider(
+            ContainerRegistryFilterProvider containerRegistryFilterProvider = new ContainerRegistryFilterProvider(
                 Options.Create(new FilterLocation()
                 {
                     EnableExternalFilter = true,

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/ContainerRegistryFilterProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/ContainerRegistryFilterProviderTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
 
         public ContainerRegistryFilterProviderTests()
         {
-            var testContainerRegistryServer = Environment.GetEnvironmentVariable("TestContainerRegistryServer");
+            string testContainerRegistryServer = Environment.GetEnvironmentVariable("TestContainerRegistryServer");
             if (testContainerRegistryServer == null)
             {
                 return;
@@ -35,8 +35,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
 
             _testImageReference = $"{testContainerRegistryServer}/synapsetestfilter:latest";
 
-            var testContainerRegistryUsername = Environment.GetEnvironmentVariable("TestContainerRegistryServer")?.Split('.')[0];
-            var testContainerRegistryPassword = Environment.GetEnvironmentVariable("TestContainerRegistryPassword");
+            string testContainerRegistryUsername = Environment.GetEnvironmentVariable("TestContainerRegistryServer")?.Split('.')[0];
+            string testContainerRegistryPassword = Environment.GetEnvironmentVariable("TestContainerRegistryPassword");
 
             _testContainerRegistryAccessToken = ContainerRegistryTestUtils.GetAcrAccessToken(testContainerRegistryUsername, testContainerRegistryPassword);
             _testTokenProvider = ContainerRegistryTestUtils.GetMockAcrTokenProvider(_testContainerRegistryAccessToken);
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _testTokenProvider,
                 _diagnosticLogger,
                 new NullLogger<ContainerRegistryFilterProvider>());
-            var filterConfiguration = await containerRegistryFilterProvider.GetFilterAsync(CancellationToken.None);
+            FilterConfiguration filterConfiguration = await containerRegistryFilterProvider.GetFilterAsync(CancellationToken.None);
 
             Assert.Equal(Common.Models.Jobs.FilterScope.System, filterConfiguration.FilterScope);
             Assert.Equal("test", filterConfiguration.TypeFilters);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/FilterManagerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/FilterManagerTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,6 +12,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
 using Microsoft.Health.Fhir.Synapse.Common.Exceptions;
 using Microsoft.Health.Fhir.Synapse.Common.Logging;
+using Microsoft.Health.Fhir.Synapse.Common.Models.FhirSearch;
 using Microsoft.Health.Fhir.Synapse.Common.Models.Jobs;
 using Microsoft.Health.Fhir.Synapse.Core.DataFilter;
 using Microsoft.Health.Fhir.Synapse.Core.Fhir.SpecificationProviders;
@@ -43,7 +45,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [Fact]
         public void GivenNullInputParameters_WhenInitialize_ExceptionShouldBeThrown()
         {
-            var fhilterConfigurationOption = Options.Create(new FilterConfiguration());
+            IOptions<FilterConfiguration> fhilterConfigurationOption = Options.Create(new FilterConfiguration());
 
             Assert.Throws<ArgumentNullException>(
                 () => new FilterManager(null, _testFhirSpecificationProvider, _diagnosticLogger, _nullFilterManagerLogger));
@@ -74,11 +76,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _diagnosticLogger,
                 _nullFilterManagerLogger);
 
-            var typeFilters = await filterManager.GetTypeFiltersAsync(default);
+            List<TypeFilter> typeFilters = await filterManager.GetTypeFiltersAsync(default);
 
             Assert.NotNull(typeFilters);
             Assert.Equal(resourceTypeCount, typeFilters.Count());
-            foreach (var typeFilter in typeFilters)
+            foreach (TypeFilter typeFilter in typeFilters)
             {
                 Assert.Empty(typeFilter.Parameters);
             }
@@ -102,7 +104,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
                 _nullFilterManagerLogger);
-            var typeFilters = await filterManager.GetTypeFiltersAsync(default);
+            List<TypeFilter> typeFilters = await filterManager.GetTypeFiltersAsync(default);
 
             Assert.Single(typeFilters);
             Assert.Equal("*", typeFilters[0].ResourceType);
@@ -127,7 +129,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
                 _nullFilterManagerLogger);
-            var typeFilters = await filterManager.GetTypeFiltersAsync(default);
+            List<TypeFilter> typeFilters = await filterManager.GetTypeFiltersAsync(default);
 
             Assert.Single(typeFilters);
             Assert.Equal("*", typeFilters[0].ResourceType);
@@ -151,7 +153,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
                 _nullFilterManagerLogger);
-            var typeFilters = await filterManager.GetTypeFiltersAsync(default);
+            List<TypeFilter> typeFilters = await filterManager.GetTypeFiltersAsync(default);
 
             Assert.Single(typeFilters);
             Assert.Equal("Patient", typeFilters[0].ResourceType);
@@ -176,7 +178,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
                 _nullFilterManagerLogger);
-            var typeFilters = await filterManager.GetTypeFiltersAsync(default);
+            List<TypeFilter> typeFilters = await filterManager.GetTypeFiltersAsync(default);
 
             Assert.Single(typeFilters);
             Assert.Equal("Patient", typeFilters[0].ResourceType);
@@ -253,7 +255,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
                 _nullFilterManagerLogger);
-            var typeFilters = await filterManager.GetTypeFiltersAsync(default);
+            List<TypeFilter> typeFilters = await filterManager.GetTypeFiltersAsync(default);
 
             Assert.NotNull(typeFilters);
             Assert.Equal(3, typeFilters.Count());
@@ -294,7 +296,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
                 _nullFilterManagerLogger);
-            var typeFilters = await filterManager.GetTypeFiltersAsync(default);
+            List<TypeFilter> typeFilters = await filterManager.GetTypeFiltersAsync(default);
 
             Assert.NotNull(typeFilters);
             Assert.Equal(3, typeFilters.Count());
@@ -349,9 +351,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
                 _nullFilterManagerLogger);
-            var typeFilters = await filterManager.GetTypeFiltersAsync(default);
+            List<TypeFilter> typeFilters = await filterManager.GetTypeFiltersAsync(default);
 
-            var expectedTypes = type.Split(',');
+            string[] expectedTypes = type.Split(',');
 
             Assert.NotNull(typeFilters);
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/FilterManagerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/FilterManagerTests.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
 
         public FilterManagerTests()
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
 
-            var metadataOptions = new MetadataOptions();
+            MetadataOptions metadataOptions = new MetadataOptions();
             dataClient.Search(metadataOptions)
                 .ReturnsForAnyArgs(x => TestDataProvider.GetBundleFromFile(TestDataConstants.R4MetadataFile));
 
@@ -63,14 +63,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("Patient,Patient", 1)]
         public async Task GivenValidTypeStringAndNullTypeFilters_WhenCreateTypeFiltersForSystem_ThenTheTypeFiltersForEachResourceTypesAreReturnedAsync(string typeString, int resourceTypeCount)
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = typeString,
                 TypeFilters = null,
             };
 
-            var filterManager = new FilterManager(
+            FilterManager filterManager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -92,14 +92,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("  ")]
         public async Task GivenNullOrWhiteSpaceTypeStringAndNullTypeFilters_WhenCreateTypeFiltersForGroup_ThenOneTypeFilterAreReturnedAsync(string typeString)
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.Group,
                 RequiredTypes = typeString,
                 TypeFilters = null,
             };
 
-            var filterManager = new FilterManager(
+            FilterManager filterManager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -117,14 +117,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("Patient,Patient", "Patient")] // *?_type=Patient
         public async Task GivenValidTypeStringAndNullTypeFilters_WhenCreateTypeFiltersForGroup_ThenOneTypeFilterAreReturnedAsync(string typeString, string expectedTypes)
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.Group,
                 RequiredTypes = typeString,
                 TypeFilters = null,
             };
 
-            var filterManager = new FilterManager(
+            FilterManager filterManager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -141,14 +141,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [Fact]
         public async Task GivenEmptyStringTypeFilter_WhenParseTypeFilter_ThenTheTypeFiltersAreReturnedAsync()
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = "Patient",
                 TypeFilters = string.Empty,
             };
 
-            var filterManager = new FilterManager(
+            FilterManager filterManager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -166,14 +166,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("  ")]
         public async Task GivenNullOrWhiteSpaceTypeFilter_WhenParseTypeFilter_ThenTheTypeFiltersAreReturnedAsync(string filterString)
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = "Patient",
                 TypeFilters = filterString,
             };
 
-            var filterManager = new FilterManager(
+            FilterManager filterManager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -200,14 +200,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
 
         public async Task GivenInvalidTypeString_WhenParseType_ExceptionShouldBeThrownAsync(FilterScope filterScope, string typeString)
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = filterScope,
                 RequiredTypes = typeString,
                 TypeFilters = null,
             };
 
-            var manager = new FilterManager(
+            FilterManager manager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -222,14 +222,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         {
             const FilterScope filterScope = (FilterScope)2;
 
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = filterScope,
                 RequiredTypes = null,
                 TypeFilters = null,
             };
 
-            var manager = new FilterManager(
+            FilterManager manager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -244,13 +244,13 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         {
             const string type = "Condition,MedicationRequest";
             const string typeFilter = "MedicationRequest?status=active,MedicationRequest?status=completed&date=gt2018-07-01T00:00:00Z";
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.Group,
                 RequiredTypes = type,
                 TypeFilters = typeFilter,
             };
-            var filterManager = new FilterManager(
+            FilterManager filterManager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -284,14 +284,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
             const string type = "Condition,MedicationRequest";
             const string typeFilter = "MedicationRequest?status=active,MedicationRequest?status=completed&date=gt2018-07-01T00:00:00Z";
 
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = type,
                 TypeFilters = typeFilter,
             };
 
-            var filterManager = new FilterManager(
+            FilterManager filterManager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -339,14 +339,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("Observation", "Observation?patient.identifier=http://example.com/fhir/identifier/mrn|123456")]
         public async Task GivenValidTypeFilter_WhenParseTypeFilter_ThenTheTypeFiltersAreReturnedAsync(string type, string typeFilter)
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = type,
                 TypeFilters = typeFilter,
             };
 
-            var filterManager = new FilterManager(
+            FilterManager filterManager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -365,14 +365,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("Patient", "P?gender=female")]
         public async Task GivenTypeFilterNotInType_WhenParseTypeFilter_ExceptionShouldBeThrownAsync(string type, string typeFilter)
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = type,
                 TypeFilters = typeFilter,
             };
 
-            var manager = new FilterManager(
+            FilterManager manager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,
@@ -410,14 +410,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("MedicationRequest", "MedicationRequest?_include=MedicationRequest:patient")]
         public async Task GivenInvalidTypeFilter_WhenParseTypeFilter_ExceptionShouldBeThrownAsync(string type, string typeFilter)
         {
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = type,
                 TypeFilters = typeFilter,
             };
 
-            var manager = new FilterManager(
+            FilterManager manager = new FilterManager(
                 new LocalFilterProvider(Options.Create(filterConfiguration)),
                 _testFhirSpecificationProvider,
                 _diagnosticLogger,

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/GroupMemberExtractorTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/GroupMemberExtractorTests.cs
@@ -66,11 +66,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
             dataClient.SearchAsync(new ResourceIdSearchOptions("Group", _sampleGroupId, null), _noneCancellationToken)
                 .ReturnsForAnyArgs(x =>
                 {
-                    var resourceId = ((ResourceIdSearchOptions)x[0]).ResourceId;
-                    var testDataFile = _groupIdToTestDataFile.ContainsKey(resourceId)
+                    string resourceId = ((ResourceIdSearchOptions)x[0]).ResourceId;
+                    string testDataFile = _groupIdToTestDataFile.ContainsKey(resourceId)
                         ? Path.Combine(_testDataFolder, _groupIdToTestDataFile[resourceId])
                         : TestDataConstants.EmptyBundleFile;
-                    var bundle =
+                    string bundle =
                         TestDataProvider.GetBundleFromFile(testDataFile);
                     return bundle;
                 });
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 ServerUrl = "https://example.com",
                 Authentication = AuthenticationType.None,
             };
-            var fhirServerOption = Options.Create(fhirServerConfig);
+            IOptions<FhirServerConfiguration> fhirServerOption = Options.Create(fhirServerConfig);
             _dataSource = new FhirApiDataSource(fhirServerOption);
             _referenceParser = new R4ReferenceParser(_dataSource, NullLogger<R4ReferenceParser>.Instance);
             _groupMemberExtractor = new GroupMemberExtractor(dataClient, _referenceParser, _diagnosticLogger, _nullGroupMemberExtractorLogger);
@@ -100,7 +100,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [Fact]
         public async Task GivenAGroupId_WhenPatientsAreRequested_ThenTheActivePatientsAreReturnedAsync()
         {
-            var resultPatientIds =
+            HashSet<string> resultPatientIds =
                 await _groupMemberExtractor.GetGroupPatientsAsync(_sampleGroupId, null, _triggerTime, _noneCancellationToken);
 
             Assert.Equal(5, resultPatientIds.Count);
@@ -118,14 +118,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
             pat4: invalid, duplicated patient while inactive
             pat9: absolute URL pointing to an internal resource
             */
-            var expectedPatientIds = new List<string> { "pat1", "pat3", "pat4", "pat6", "pat9" };
-            var unExpectedPatientIds = new List<string> { "pat2", "pat5", "pat7", "pat8" };
-            foreach (var expectedPatientId in expectedPatientIds)
+            List<string> expectedPatientIds = new List<string> { "pat1", "pat3", "pat4", "pat6", "pat9" };
+            List<string> unExpectedPatientIds = new List<string> { "pat2", "pat5", "pat7", "pat8" };
+            foreach (string expectedPatientId in expectedPatientIds)
             {
                 Assert.Contains(expectedPatientId, resultPatientIds);
             }
 
-            foreach (var unExpectedPatientId in unExpectedPatientIds)
+            foreach (string unExpectedPatientId in unExpectedPatientIds)
             {
                 Assert.DoesNotContain(unExpectedPatientId, resultPatientIds);
             }
@@ -135,7 +135,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         public async Task
             GivenAGroupIdForAGroupWithANestedGroup_WhenPatientsAreRequested_ThenTheActivePatientsAreReturnedAsync()
         {
-            var resultPatientIds =
+            HashSet<string> resultPatientIds =
                 await _groupMemberExtractor.GetGroupPatientsAsync(_nestedGroupId, null, _triggerTime, _noneCancellationToken);
 
             Assert.Equal(7, resultPatientIds.Count);
@@ -144,14 +144,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
             // the new patient groupPat1 is included
             // the duplicate patient pat1 is included and deduplicated.
             // the duplicate patient pat2 is included.
-            var expectedPatientIds = new List<string> { "pat1", "pat2", "pat3", "pat4", "pat6", "pat9", "groupPat1" };
-            var unExpectedPatientIds = new List<string> { "pat5", "pat7", "pat8" };
-            foreach (var expectedPatientId in expectedPatientIds)
+            List<string> expectedPatientIds = new List<string> { "pat1", "pat2", "pat3", "pat4", "pat6", "pat9", "groupPat1" };
+            List<string> unExpectedPatientIds = new List<string> { "pat5", "pat7", "pat8" };
+            foreach (string expectedPatientId in expectedPatientIds)
             {
                 Assert.Contains(expectedPatientId, resultPatientIds);
             }
 
-            foreach (var unExpectedPatientId in unExpectedPatientIds)
+            foreach (string unExpectedPatientId in unExpectedPatientIds)
             {
                 Assert.DoesNotContain(unExpectedPatientId, resultPatientIds);
             }
@@ -168,7 +168,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 int numberOfResources)
         {
             var dateTimeOffset = new DateTimeOffset(new DateTime(year, 1, 1));
-            var resultPatientIds = await _groupMemberExtractor.GetGroupPatientsAsync(
+            HashSet<string> resultPatientIds = await _groupMemberExtractor.GetGroupPatientsAsync(
                 _sampleGroupId,
                 null,
                 dateTimeOffset,
@@ -212,7 +212,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         public async Task
             GivenAGroupIdForAGroupWithInvalidMembers_WhenPatientsAreRequested_ThenTheEmptyResultAreReturnedAsync()
         {
-            var result = await _groupMemberExtractor.GetGroupPatientsAsync(
+            HashSet<string> result = await _groupMemberExtractor.GetGroupPatientsAsync(
                 _invalidMembersGroupId,
                 null,
                 _triggerTime,

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/GroupMemberExtractorTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/GroupMemberExtractorTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
 
         public GroupMemberExtractorTests()
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
 
             dataClient.SearchAsync(new ResourceIdSearchOptions("Group", _sampleGroupId, null), _noneCancellationToken)
                 .ReturnsForAnyArgs(x =>
@@ -75,7 +75,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                     return bundle;
                 });
 
-            var fhirServerConfig = new FhirServerConfiguration
+            FhirServerConfiguration fhirServerConfig = new FhirServerConfiguration
             {
                 ServerUrl = "https://example.com",
                 Authentication = AuthenticationType.None,
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
             Assert.Throws<ArgumentNullException>(
                 () => new GroupMemberExtractor(null, _referenceParser, _diagnosticLogger, _nullGroupMemberExtractorLogger));
 
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
             Assert.Throws<ArgumentNullException>(
                 () => new GroupMemberExtractor(dataClient, null, _diagnosticLogger, _nullGroupMemberExtractorLogger));
         }
@@ -167,7 +167,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 int year,
                 int numberOfResources)
         {
-            var dateTimeOffset = new DateTimeOffset(new DateTime(year, 1, 1));
+            DateTimeOffset dateTimeOffset = new DateTimeOffset(new DateTime(year, 1, 1));
             HashSet<string> resultPatientIds = await _groupMemberExtractor.GetGroupPatientsAsync(
                 _sampleGroupId,
                 null,
@@ -180,7 +180,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [Fact]
         public async Task GivenNoFoundGroupId_WhenGetGroupPatients_ExceptionShouldBeThrown()
         {
-            var exception = await Assert.ThrowsAsync<GroupMemberExtractorException>(() => _groupMemberExtractor.GetGroupPatientsAsync(_notFoundGroupId, null, _triggerTime, _noneCancellationToken));
+            GroupMemberExtractorException exception = await Assert.ThrowsAsync<GroupMemberExtractorException>(() => _groupMemberExtractor.GetGroupPatientsAsync(_notFoundGroupId, null, _triggerTime, _noneCancellationToken));
             Assert.StartsWith($"Failed to extract group members. Reason: Group {_notFoundGroupId} is not found.", exception.Message);
         }
 
@@ -190,21 +190,21 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("  ")]
         public async Task GivenNullOrWhiteSpaceGroupId_WhenGetGroupPatients_ExceptionShouldBeThrown(string groupId)
         {
-            var exception = await Assert.ThrowsAsync<GroupMemberExtractorException>(() => _groupMemberExtractor.GetGroupPatientsAsync(groupId, null, _triggerTime, _noneCancellationToken));
+            GroupMemberExtractorException exception = await Assert.ThrowsAsync<GroupMemberExtractorException>(() => _groupMemberExtractor.GetGroupPatientsAsync(groupId, null, _triggerTime, _noneCancellationToken));
             Assert.Equal($"Failed to extract group members. Reason: The input group id is null or white space.", exception.Message);
         }
 
         [Fact]
         public async Task GivenInvalidBundle_WhenGetGroupPatients_ExceptionShouldBeThrown()
         {
-            var exception = await Assert.ThrowsAsync<GroupMemberExtractorException>(() => _groupMemberExtractor.GetGroupPatientsAsync(_invalidBundle, null, _triggerTime, _noneCancellationToken));
+            GroupMemberExtractorException exception = await Assert.ThrowsAsync<GroupMemberExtractorException>(() => _groupMemberExtractor.GetGroupPatientsAsync(_invalidBundle, null, _triggerTime, _noneCancellationToken));
             Assert.StartsWith($"Failed to extract group members. Reason: Failed to parse fhir 'Group' bundle ", exception.Message);
         }
 
         [Fact]
         public async Task GivenInvalidGroupBundle_WhenGetGroupPatients_ExceptionShouldBeThrown()
         {
-            var exception = await Assert.ThrowsAsync<GroupMemberExtractorException>(() => _groupMemberExtractor.GetGroupPatientsAsync(_invalidGroup, null, _triggerTime, _noneCancellationToken));
+            GroupMemberExtractorException exception = await Assert.ThrowsAsync<GroupMemberExtractorException>(() => _groupMemberExtractor.GetGroupPatientsAsync(_invalidGroup, null, _triggerTime, _noneCancellationToken));
             Assert.StartsWith($"Failed to extract group members. Reason: There are invalid group entries returned: ", exception.Message);
         }
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/R4ReferenceParserTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/R4ReferenceParserTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
 
         public R4ReferenceParserTests()
         {
-            var fhirServerConfig = new FhirServerConfiguration
+            FhirServerConfiguration fhirServerConfig = new FhirServerConfiguration
             {
                 ServerUrl = _serverUrl,
                 Authentication = AuthenticationType.None,
@@ -51,7 +51,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("   ")]
         public void GivenNullOrWhiteSpaceReference_WhenParseReference_ExceptionShouldBeThrown(string reference)
         {
-            var exception = Assert.Throws<ReferenceParseException>(() => _referenceParser.Parse(reference));
+            ReferenceParseException exception = Assert.Throws<ReferenceParseException>(() => _referenceParser.Parse(reference));
             Assert.Equal("The reference string is null or white space.", exception.Message);
         }
 
@@ -71,15 +71,15 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [Fact]
         public void GivenDataSourceServerUrlEndsWithSlash_WhenParseReference_ParsedReferenceShouldBeReturned()
         {
-            var fhirServerConfig = new FhirServerConfiguration
+            FhirServerConfiguration fhirServerConfig = new FhirServerConfiguration
             {
                 ServerUrl = "https://example.com/",
                 Authentication = AuthenticationType.None,
             };
 
             IOptions<FhirServerConfiguration> fhirServerOption = Options.Create(fhirServerConfig);
-            var dataSource = new FhirApiDataSource(fhirServerOption);
-            var referenceParser = new R4ReferenceParser(dataSource, _nullR4ReferenceParserLogger);
+            FhirApiDataSource dataSource = new FhirApiDataSource(fhirServerOption);
+            R4ReferenceParser referenceParser = new R4ReferenceParser(dataSource, _nullR4ReferenceParserLogger);
 
             FhirReference fhirReference = referenceParser.Parse("https://example.com/Patient/123/_history/2");
             Assert.NotNull(fhirReference);
@@ -97,7 +97,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("#p1")]
         public void GivenInvalidReference_WhenParseReference_ExceptionShouldBeThrown(string reference)
         {
-            var exception = Assert.Throws<ReferenceParseException>(() => _referenceParser.Parse(reference));
+            ReferenceParseException exception = Assert.Throws<ReferenceParseException>(() => _referenceParser.Parse(reference));
             Assert.Equal($"Fail to parse reference {reference}.", exception.Message);
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("http://fhir.hl7.org/svc/StructureDefinition/c8973a22-2b5b-4e76-9c66-00639c99e61b")]
         public void GivenExternalAbsoluteURL_WhenParseReference_ExceptionShouldBeThrown(string reference)
         {
-            var exception = Assert.Throws<ReferenceParseException>(() => _referenceParser.Parse(reference));
+            ReferenceParseException exception = Assert.Throws<ReferenceParseException>(() => _referenceParser.Parse(reference));
             Assert.Equal($"The reference {reference} is an absolute URL pointing to an external resource.", exception.Message);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/R4ReferenceParserTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataFilter/R4ReferenceParserTests.cs
@@ -7,6 +7,7 @@ using System;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
+using Microsoft.Health.Fhir.Synapse.Common.Models.FhirSearch;
 using Microsoft.Health.Fhir.Synapse.Core.DataFilter;
 using Microsoft.Health.Fhir.Synapse.Core.Exceptions;
 using Microsoft.Health.Fhir.Synapse.DataClient.Api;
@@ -32,7 +33,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 ServerUrl = _serverUrl,
                 Authentication = AuthenticationType.None,
             };
-            var fhirServerOption = Options.Create(fhirServerConfig);
+            IOptions<FhirServerConfiguration> fhirServerOption = Options.Create(fhirServerConfig);
             _dataSource = new FhirApiDataSource(fhirServerOption);
             _referenceParser = new R4ReferenceParser(_dataSource, _nullR4ReferenceParserLogger);
         }
@@ -61,7 +62,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
         [InlineData("https://example.com/Patient/123/_history/2")]
         public void GivenValidReference_WhenParseReference_ParsedReferenceShouldBeReturned(string reference)
         {
-            var fhirReference = _referenceParser.Parse(reference);
+            FhirReference fhirReference = _referenceParser.Parse(reference);
             Assert.NotNull(fhirReference);
             Assert.Equal("Patient", fhirReference.ResourceType);
             Assert.Equal("123", fhirReference.ResourceId);
@@ -76,11 +77,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataFilter
                 Authentication = AuthenticationType.None,
             };
 
-            var fhirServerOption = Options.Create(fhirServerConfig);
+            IOptions<FhirServerConfiguration> fhirServerOption = Options.Create(fhirServerConfig);
             var dataSource = new FhirApiDataSource(fhirServerOption);
             var referenceParser = new R4ReferenceParser(dataSource, _nullR4ReferenceParserLogger);
 
-            var fhirReference = referenceParser.Parse("https://example.com/Patient/123/_history/2");
+            FhirReference fhirReference = referenceParser.Parse("https://example.com/Patient/123/_history/2");
             Assert.NotNull(fhirReference);
             Assert.Equal("Patient", fhirReference.ResourceType);
             Assert.Equal("123", fhirReference.ResourceId);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/DataConverter/CustomSchemaConverterTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/DataConverter/CustomSchemaConverterTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -25,7 +26,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
 
         static CustomSchemaConverterTests()
         {
-            var schemaConfigurationOptionWithCustomizedSchema = Options.Create(new SchemaConfiguration()
+            IOptions<SchemaConfiguration> schemaConfigurationOptionWithCustomizedSchema = Options.Create(new SchemaConfiguration()
             {
                 EnableCustomizedSchema = true,
                 SchemaImageReference = "testacr.azurecr.io/customizedtemplate:default",
@@ -37,7 +38,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
                 new DiagnosticLogger(),
                 NullLogger<CustomSchemaConverter>.Instance);
 
-            var testDataContent = File.ReadLines(Path.Join(TestUtils.TestDataFolder, "Basic_Raw_Patient.ndjson"))
+            IEnumerable<JObject> testDataContent = File.ReadLines(Path.Join(TestUtils.TestDataFolder, "Basic_Raw_Patient.ndjson"))
                         .Select(dataContent => JObject.Parse(dataContent));
 
             _testData = new JsonBatchData(testDataContent);
@@ -46,9 +47,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
         [Fact]
         public void GivenAValidJsonBatchData_WhenConvert_CorrectResultShouldBeReturned()
         {
-            var result = _testFhirConverter.Convert(_testData, "Patient").Values.ToList();
+            List<JObject> result = _testFhirConverter.Convert(_testData, "Patient").Values.ToList();
 
-            var expectedResult = File.ReadLines(Path.Join(TestUtils.ExpectTestDataFolder, "CustomizedSchema/Expected_basic_patient.ndjson"))
+            List<JObject> expectedResult = File.ReadLines(Path.Join(TestUtils.ExpectTestDataFolder, "CustomizedSchema/Expected_basic_patient.ndjson"))
                         .Select(dataContent => JObject.Parse(dataContent)).ToList();
 
             Assert.Equal(expectedResult.Count, result.Count);
@@ -77,7 +78,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
         [Fact]
         public void GivenInvalidResourceType_WhenPreprocess_ExceptionShouldBeThrown()
         {
-            var testData = File.ReadLines(Path.Join(TestUtils.TestDataFolder, "Basic_Raw_Patient.ndjson"))
+            IEnumerable<JObject> testData = File.ReadLines(Path.Join(TestUtils.TestDataFolder, "Basic_Raw_Patient.ndjson"))
                     .Select(dataContent => JObject.Parse(dataContent));
 
             Assert.Throws<ParquetDataProcessorException>(() => _testFhirConverter.Convert(new JsonBatchData(testData), "Invalid resource type"));

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/DataConverter/DefaultSchemaConverterTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/DataConverter/DefaultSchemaConverterTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
 
         static DefaultSchemaConverterTests()
         {
-            var schemaConfigurationOption = Options.Create(new SchemaConfiguration());
+            IOptions<SchemaConfiguration> schemaConfigurationOption = Options.Create(new SchemaConfiguration());
 
             var schemaManager = new FhirParquetSchemaManager(
                 schemaConfigurationOption,
@@ -42,11 +42,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
         [Fact]
         public void GivenAValidBasicSchema_WhenConvert_CorrectResultShouldBeReturned()
         {
-            var result = _testDefaultConverter.Convert(
+            JsonBatchData result = _testDefaultConverter.Convert(
                 CreateTestJsonBatchData(_testPatient),
                 "Patient");
 
-            var expectedResult = TestUtils.LoadNdjsonData(Path.Combine(TestUtils.ExpectTestDataFolder, "Expected_Processed_Patient.ndjson"));
+            IEnumerable<JObject> expectedResult = TestUtils.LoadNdjsonData(Path.Combine(TestUtils.ExpectTestDataFolder, "Expected_Processed_Patient.ndjson"));
 
             Assert.True(JToken.DeepEquals(result.Values.First(), expectedResult.First()));
         }
@@ -77,7 +77,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
                 },
             };
 
-            var result = _testDefaultConverter.Convert(
+            JsonBatchData result = _testDefaultConverter.Convert(
                 CreateTestJsonBatchData(rawStructFormatData),
                 "Patient");
             Assert.True(JToken.DeepEquals(result.Values.First(), expectedStructFormatResult));
@@ -127,7 +127,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
                 },
             };
 
-            var result = _testDefaultConverter.Convert(
+            JsonBatchData result = _testDefaultConverter.Convert(
                 CreateTestJsonBatchData(rawArrayFormatData),
                 "Patient");
             Assert.True(JToken.DeepEquals(result.Values.First(), expectedArrayFormatResult));
@@ -189,7 +189,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
                 },
             };
 
-            var result = _testDefaultConverter.Convert(
+            JsonBatchData result = _testDefaultConverter.Convert(
                 CreateTestJsonBatchData(rawDeepFieldsData),
                 "Patient");
             Assert.True(JToken.DeepEquals(result.Values.First(), expectedJsonStringFieldsResult));
@@ -251,7 +251,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
                 },
             };
 
-            var result = _testDefaultConverter.Convert(
+            JsonBatchData result = _testDefaultConverter.Convert(
                 CreateTestJsonBatchData(rawDeepFieldsData),
                 "Patient");
             Assert.True(JToken.DeepEquals(result.Values.First(), expectedJsonStringFieldsResult));
@@ -271,7 +271,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
                 { "effective", new JObject { { "dateTime", "1905-08-23" } } },
             };
 
-            var result = _testDefaultConverter.Convert(
+            JsonBatchData result = _testDefaultConverter.Convert(
                 CreateTestJsonBatchData(rawPrimitiveChoiceTypeData),
                 "Observation");
             Assert.True(JToken.DeepEquals(result.Values.First(), expectedPrimitiveChoiceTypeResult));
@@ -291,7 +291,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
                 { "effective", new JObject { { "period", new JObject { { "start", "1905-08-23" } } } } },
             };
 
-            var result = _testDefaultConverter.Convert(
+            JsonBatchData result = _testDefaultConverter.Convert(
                 CreateTestJsonBatchData(rawStructChoiceTypeData),
                 "Observation");
             Assert.True(JToken.DeepEquals(result.Values.First(), expectedStructChoiceTypeResult));
@@ -328,7 +328,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
 
         private static JsonBatchData CreateTestJsonBatchData(JObject testJObjectData)
         {
-            var testData = new List<JObject>() { testJObjectData };
+            List<JObject> testData = new List<JObject>() { testJObjectData };
             return new JsonBatchData(testData);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/DataConverter/DefaultSchemaConverterTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/DataConverter/DefaultSchemaConverterTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
         {
             IOptions<SchemaConfiguration> schemaConfigurationOption = Options.Create(new SchemaConfiguration());
 
-            var schemaManager = new FhirParquetSchemaManager(
+            FhirParquetSchemaManager schemaManager = new FhirParquetSchemaManager(
                 schemaConfigurationOption,
                 TestUtils.TestParquetSchemaProviderDelegate,
                 NullLogger<FhirParquetSchemaManager>.Instance);
@@ -314,7 +314,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor.DataConvert
         [Fact]
         public void GivenInvalidData_WhenConvert_ExceptionShouldBeReturned()
         {
-            var invalidFieldData = new JObject
+            JObject invalidFieldData = new JObject
             {
                 { "name", "Invalid data fields, should be array." },
             };

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/ParquetDataProcessorTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/ParquetDataProcessorTests.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
 
         static ParquetDataProcessorTests()
         {
-            var fhirSchemaManagerWithoutCustomizedSchema = new FhirParquetSchemaManager(
+            FhirParquetSchemaManager fhirSchemaManagerWithoutCustomizedSchema = new FhirParquetSchemaManager(
                 Options.Create(new SchemaConfiguration()),
                 TestUtils.TestParquetSchemaProviderDelegate,
                 NullLogger<FhirParquetSchemaManager>.Instance);
 
-            var fhirSchemaManagerWithCustomizedSchema = new FhirParquetSchemaManager(
+            FhirParquetSchemaManager fhirSchemaManagerWithCustomizedSchema = new FhirParquetSchemaManager(
                 Options.Create(TestUtils.TestCustomSchemaConfiguration),
                 TestUtils.TestParquetSchemaProviderDelegate,
                 NullLogger<FhirParquetSchemaManager>.Instance);
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
         [Fact]
         public void GivenNullInputParameters_WhenInitialize_ExceptionShouldBeThrown()
         {
-            var fhirSchemaManager = new FhirParquetSchemaManager(
+            FhirParquetSchemaManager fhirSchemaManager = new FhirParquetSchemaManager(
                 Options.Create(new SchemaConfiguration()),
                 TestUtils.TestParquetSchemaProviderDelegate,
                 NullLogger<FhirParquetSchemaManager>.Instance);
@@ -95,11 +95,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
         [Fact]
         public async Task GivenAValidInputData_WhenProcessWithoutCustomizedSchema_CorrectResultShouldBeReturned()
         {
-            var jsonBatchData = new JsonBatchData(_testPatients);
+            JsonBatchData jsonBatchData = new JsonBatchData(_testPatients);
 
             StreamBatchData resultBatchData = await _testParquetDataProcessorWithoutCustomizedSchema.ProcessAsync(jsonBatchData, new ProcessParameters("Patient", "Patient"));
 
-            var resultStream = new MemoryStream();
+            MemoryStream resultStream = new MemoryStream();
             resultBatchData.Value.CopyTo(resultStream);
 
             MemoryStream expectedResult = GetExpectedParquetStream(Path.Combine(TestUtils.ExpectTestDataFolder, "Expected_Patient.parquet"));
@@ -114,7 +114,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
                 new JsonBatchData(_testPatients),
                 new ProcessParameters($"Patient{FhirParquetSchemaConstants.CustomizedSchemaSuffix}", "Patient"));
 
-            var resultStream = new MemoryStream();
+            MemoryStream resultStream = new MemoryStream();
             resultBatchData.Value.CopyTo(resultStream);
 
             MemoryStream expectedResult = GetExpectedParquetStream(Path.Combine(TestUtils.ExpectTestDataFolder, "Expected_Patient_Customized.parquet"));
@@ -131,11 +131,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
             // Maximum row number for arrow cpp parser is 100000 for a block, see https://github.com/apache/arrow/blob/42a9b32141c3c5a7178bef6644872d14f3051ce6/cpp/src/arrow/json/parser.h#L51
             IEnumerable<JObject> largeTestData = Enumerable.Repeat(largePatientSingleSet, 10).SelectMany(x => x);
 
-            var jsonBatchData = new JsonBatchData(largeTestData);
+            JsonBatchData jsonBatchData = new JsonBatchData(largeTestData);
 
             StreamBatchData resultBatchData = await _testParquetDataProcessorWithoutCustomizedSchema.ProcessAsync(jsonBatchData, new ProcessParameters("Patient", "Patient"));
 
-            var resultStream = new MemoryStream();
+            MemoryStream resultStream = new MemoryStream();
             resultBatchData.Value.CopyTo(resultStream);
 
             MemoryStream expectedResult = GetExpectedParquetStream(Path.Combine(TestUtils.ExpectTestDataFolder, "Expected_Patient_MultipleLargeSize.parquet"));
@@ -149,11 +149,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
         {
             IEnumerable<JObject> largePatientSingleSet = TestUtils.LoadNdjsonData(Path.Combine(TestUtils.TestDataFolder, "Large_Patient.ndjson"));
 
-            var jsonBatchData = new JsonBatchData(largePatientSingleSet);
+            JsonBatchData jsonBatchData = new JsonBatchData(largePatientSingleSet);
 
             StreamBatchData resultBatchData = await _testParquetDataProcessorWithoutCustomizedSchema.ProcessAsync(jsonBatchData, new ProcessParameters("Patient", "Patient"));
 
-            var resultStream = new MemoryStream();
+            MemoryStream resultStream = new MemoryStream();
             resultBatchData.Value.CopyTo(resultStream);
 
             MemoryStream expectedResult = GetExpectedParquetStream(Path.Combine(TestUtils.ExpectTestDataFolder, "Expected_Patient_LargeSize.parquet"));
@@ -164,7 +164,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
         [Fact]
         public async Task GivenDataWithSomeRecordsLengthLargerThanBlockSize_WhenProcess_LargeRecordsShouldBeIgnored()
         {
-            var shortPatientData = new JObject
+            JObject shortPatientData = new JObject
             {
                 { "resourceType", "Patient" },
                 { "id", "example" },
@@ -178,18 +178,18 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
                 ReadOptions = new ArrowReadOptionsConfiguration() { BlockSize = 50 },
             });
 
-            var parquetDataProcessor = new ParquetDataProcessor(
+            ParquetDataProcessor parquetDataProcessor = new ParquetDataProcessor(
                 _testDefaultFhirSchemaManager,
                 arrowConfigurationOptions,
                 TestUtils.TestDataSchemaConverterDelegate,
                 _diagnosticLogger,
                 NullLogger<ParquetDataProcessor>.Instance);
 
-            var jsonBatchData = new JsonBatchData(testData);
+            JsonBatchData jsonBatchData = new JsonBatchData(testData);
 
             StreamBatchData resultBatchData = await parquetDataProcessor.ProcessAsync(jsonBatchData, new ProcessParameters("Patient", "Patient"));
 
-            var resultStream = new MemoryStream();
+            MemoryStream resultStream = new MemoryStream();
             resultBatchData.Value.CopyTo(resultStream);
 
             MemoryStream expectedResult = GetExpectedParquetStream(Path.Combine(TestUtils.ExpectTestDataFolder, "Expected_Patient_IgnoreLargeLength.parquet"));
@@ -206,7 +206,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
                 ReadOptions = new ArrowReadOptionsConfiguration() { BlockSize = 50 },
             });
 
-            var parquetDataProcessor = new ParquetDataProcessor(
+            ParquetDataProcessor parquetDataProcessor = new ParquetDataProcessor(
                 _testDefaultFhirSchemaManager,
                 arrowConfigurationOptions,
                 TestUtils.TestDataSchemaConverterDelegate,
@@ -214,7 +214,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
                 NullLogger<ParquetDataProcessor>.Instance);
 
             List<JObject> testData = new List<JObject>(_testPatients);
-            var jsonBatchData = new JsonBatchData(testData);
+            JsonBatchData jsonBatchData = new JsonBatchData(testData);
 
             StreamBatchData result = await parquetDataProcessor.ProcessAsync(jsonBatchData, new ProcessParameters("Patient", "Patient"));
             Assert.Null(result);
@@ -223,7 +223,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
         [Fact]
         public async Task GivenInvalidSchemaOrResourceType_WhenProcess_ExceptionShouldBeThrown()
         {
-            var jsonBatchData = new JsonBatchData(_testPatients);
+            JsonBatchData jsonBatchData = new JsonBatchData(_testPatients);
 
             await Assert.ThrowsAsync<ParquetDataProcessorException>(
                 () => _testParquetDataProcessorWithoutCustomizedSchema.ProcessAsync(jsonBatchData, new ProcessParameters("InvalidSchemaType", "InvalidSchemaType")));
@@ -232,13 +232,13 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
         [Fact]
         public async Task GivenInvalidJsonBatchData_WhenProcess_ExceptionShouldBeThrown()
         {
-            var invalidTestData = new JObject
+            JObject invalidTestData = new JObject
             {
                 { "resourceType", "Patient" },
                 { "name", "Invalid field content, should be an array." },
             };
 
-            var invalidJsonBatchData = new JsonBatchData(new List<JObject> { invalidTestData, invalidTestData });
+            JsonBatchData invalidJsonBatchData = new JsonBatchData(new List<JObject> { invalidTestData, invalidTestData });
 
             await Assert.ThrowsAsync<ParquetDataProcessorException>(
                 () => _testParquetDataProcessorWithoutCustomizedSchema.ProcessAsync(invalidJsonBatchData, new ProcessParameters("Patient", "Patient")));
@@ -246,8 +246,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
 
         private static MemoryStream GetExpectedParquetStream(string filePath)
         {
-            var expectedResult = new MemoryStream();
-            using var file = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+            MemoryStream expectedResult = new MemoryStream();
+            using FileStream file = new FileStream(filePath, FileMode.Open, FileAccess.Read);
             file.CopyTo(expectedResult);
 
             return expectedResult;

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Extensions/DictionaryExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Extensions/DictionaryExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenANewKey_WhenAddToDictionary_TheKeyValuePairShouldBeAddedToDictionary()
         {
-            var dic = new Dictionary<string, int> { { _key, 1 } };
+            Dictionary<string, int> dic = new Dictionary<string, int> { { _key, 1 } };
             dic = dic.AddToDictionary("b", 2);
             Assert.Equal(2, dic.Count);
             Assert.True(dic.ContainsKey(_key));
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenAnExistingKey_WhenAddToDictionary_TheValueShouldBeAddedToDictionary()
         {
-            var dic = new Dictionary<string, int> { { _key, 1 } };
+            Dictionary<string, int> dic = new Dictionary<string, int> { { _key, 1 } };
             dic = dic.AddToDictionary(_key, 2);
             Assert.Single(dic);
             Assert.True(dic.ContainsKey(_key));
@@ -39,7 +39,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenEmptyDictionary_WhenAddToDictionary_TheKeyValuePairShouldBeAddedToDictionary()
         {
-            var dic = new Dictionary<string, int>();
+            Dictionary<string, int> dic = new Dictionary<string, int>();
             dic = dic.AddToDictionary(_key, 1);
             Assert.Single(dic);
             Assert.True(dic.ContainsKey(_key));
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenSameKeyMultiTimes_WhenAddToDictionary_TheValuePairShouldBeAddedToDictionary()
         {
-            var dic = new Dictionary<string, int> { { _key, 1 } };
+            Dictionary<string, int> dic = new Dictionary<string, int> { { _key, 1 } };
             dic = dic.AddToDictionary(_key, 1);
             Assert.Single(dic);
             Assert.True(dic.ContainsKey(_key));
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenNullOrEmptyKey_WhenAddToDictionary_ExceptionShouldBeThrown()
         {
-            var dic = new Dictionary<string, int>();
+            Dictionary<string, int> dic = new Dictionary<string, int>();
             Assert.Throws<ArgumentNullException>(() => dic.AddToDictionary(null, 1));
             Assert.Throws<ArgumentException>(() => dic.AddToDictionary(string.Empty, 1));
         }
@@ -84,8 +84,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenValidDictionary_WhenConcatDictionaryCount_TheDictionaryShouldBeConcatCorrectly()
         {
-            var dic1 = new Dictionary<string, int> { { "key1", 1 }, { "key2", 2 } };
-            var dic2 = new Dictionary<string, int> { { "key2", 3 }, { "key3", 4 } };
+            Dictionary<string, int> dic1 = new Dictionary<string, int> { { "key1", 1 }, { "key2", 2 } };
+            Dictionary<string, int> dic2 = new Dictionary<string, int> { { "key2", 3 }, { "key3", 4 } };
             dic1 = dic1.ConcatDictionaryCount(dic2);
 
             Assert.Equal(3, dic1.Count);
@@ -100,13 +100,13 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenEmptyDictionary_WhenConcatDictionaryCount_TheDictionaryShouldNoChange()
         {
-            var dic1 = new Dictionary<string, int> { { "key1", 1 }, { "key2", 2 } };
-            var dic2 = new Dictionary<string, int>();
-            var dic = dic1.ConcatDictionaryCount(dic2);
+            Dictionary<string, int> dic1 = new Dictionary<string, int> { { "key1", 1 }, { "key2", 2 } };
+            Dictionary<string, int> dic2 = new Dictionary<string, int>();
+            Dictionary<string, int> dic = dic1.ConcatDictionaryCount(dic2);
 
             Assert.Equal(dic1.Count, dic.Count);
 
-            foreach (var (key, value) in dic)
+            foreach ((string key, int value) in dic)
             {
                 Assert.True(dic1.ContainsKey(key));
                 Assert.Equal(dic1[key], dic[key]);
@@ -116,7 +116,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenNullDictionary_WhenConcatDictionaryCount_ExceptionShouldBeThrown()
         {
-            var dic1 = new Dictionary<string, int>();
+            Dictionary<string, int> dic1 = new Dictionary<string, int>();
             Assert.Throws<ArgumentNullException>(() => dic1.ConcatDictionaryCount(null));
 
             Dictionary<string, int> dic2 = null;

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Extensions/ITypedElementExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Extensions/ITypedElementExtensionsTests.cs
@@ -10,6 +10,7 @@ using Hl7.Fhir.ElementModel;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
+using Microsoft.Health.Fhir.Synapse.Common.Models.Data;
 using Microsoft.Health.Fhir.Synapse.Core.Extensions;
 using Microsoft.Health.Fhir.Synapse.Core.Fhir;
 using Xunit;
@@ -78,21 +79,21 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         public void GivenAnEmptyElementDataList_WhenConvertToJObjects_EmptyBatchDataShouldReturn()
         {
             List<ITypedElement> elements = new List<ITypedElement>();
-            var jsonBatchData = elements.ToJsonBatchData();
+            JsonBatchData jsonBatchData = elements.ToJsonBatchData();
             Assert.Empty(jsonBatchData.Values);
 
             IEnumerable<ITypedElement> nullElements = null;
-            var jsonBatchData2 = nullElements.ToJsonBatchData();
+            JsonBatchData jsonBatchData2 = nullElements.ToJsonBatchData();
             Assert.Null(jsonBatchData2);
         }
 
         private ITypedElement GetTestElement(string fileName)
         {
-            var fhirConfiguration = new FhirServerConfiguration()
+            FhirServerConfiguration fhirConfiguration = new FhirServerConfiguration()
             {
                 Version = FhirVersion.R4,
             };
-            var fhirParser = new FhirSerializer(Options.Create(fhirConfiguration));
+            FhirSerializer fhirParser = new FhirSerializer(Options.Create(fhirConfiguration));
             return fhirParser.DeserializeToElement(File.ReadAllText(fileName));
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Extensions/ITypedElementExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Extensions/ITypedElementExtensionsTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Hl7.Fhir.ElementModel;
@@ -33,9 +34,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenATypedElement_WhenGetAPropertyNotExists_NullValueShouldReturn()
         {
-            var testElement = GetTestElement(SamplePatientFileName);
+            ITypedElement testElement = GetTestElement(SamplePatientFileName);
 
-            var value = testElement.GetPropertyValue("abc")?.ToString();
+            string value = testElement.GetPropertyValue("abc")?.ToString();
 
             Assert.Null(value);
         }
@@ -44,9 +45,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [MemberData(nameof(GetPropertyValuePairs))]
         public void GivenATypedElement_WhenGetPropertyValue_CorrectValueShouldReturn(string propertyName, string expectedValue)
         {
-            var testElement = GetTestElement(SamplePatientFileName);
+            ITypedElement testElement = GetTestElement(SamplePatientFileName);
 
-            var value = testElement.GetPropertyValue(propertyName).ToString();
+            string value = testElement.GetPropertyValue(propertyName).ToString();
 
             Assert.Equal(expectedValue, value);
         }
@@ -54,9 +55,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenATypedElement_WhenGetLastUpdatedDay_CorrectResultShouldReturn()
         {
-            var testElement = GetTestElement(SamplePatientFileName);
+            ITypedElement testElement = GetTestElement(SamplePatientFileName);
 
-            var date = testElement.GetLastUpdatedDay();
+            DateTime? date = testElement.GetLastUpdatedDay();
 
             Assert.Equal(2012, date.Value.Year);
             Assert.Equal(6, date.Value.Month);
@@ -66,9 +67,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenATypedElementWithoutLastUpdatedDay_WhenGetLastUpdatedDay_NullShouldReturn()
         {
-            var testElement = GetTestElement(NoMetaSamplePatientFileName);
+            ITypedElement testElement = GetTestElement(NoMetaSamplePatientFileName);
 
-            var date = testElement.GetLastUpdatedDay();
+            DateTime? date = testElement.GetLastUpdatedDay();
 
             Assert.Null(date);
         }
@@ -76,7 +77,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenAnEmptyElementDataList_WhenConvertToJObjects_EmptyBatchDataShouldReturn()
         {
-            var elements = new List<ITypedElement>();
+            List<ITypedElement> elements = new List<ITypedElement>();
             var jsonBatchData = elements.ToJsonBatchData();
             Assert.Empty(jsonBatchData.Values);
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Extensions/JObjectExtensionsTest.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Extensions/JObjectExtensionsTest.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System;
 using System.IO;
 using Microsoft.Health.Fhir.Synapse.Core.Exceptions;
 using Microsoft.Health.Fhir.Synapse.Core.Extensions;
@@ -19,9 +20,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenAJObject_WhenGetLastUpdated_CorrectResultShouldReturn()
         {
-            var testJObject = GetTestJObject(SamplePatientFileName);
+            JObject testJObject = GetTestJObject(SamplePatientFileName);
 
-            var date = testJObject.GetLastUpdated();
+            DateTimeOffset? date = testJObject.GetLastUpdated();
             Assert.NotNull(date);
 
             Assert.Equal(2012, date.Value.Year);
@@ -32,7 +33,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Extensions
         [Fact]
         public void GivenAJObjectWithoutLastUpdated_WhenGetLastUpdated_ExceptionShouldBeThrown()
         {
-            var testJObject = GetTestJObject(NoMetaSamplePatientFileName);
+            JObject testJObject = GetTestJObject(NoMetaSamplePatientFileName);
 
             Assert.Throws<FhirDataParseException>(() => testJObject.GetLastUpdated());
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/FhirBundleParserTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/FhirBundleParserTests.cs
@@ -18,10 +18,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void GivenAnEmptyBundle_WhenParsingBundle_EmptyResultShouldBeReturned()
         {
-            var bundle = TestDataProvider.GetBundleJsonFromFile(TestDataConstants.EmptyBundleFile);
+            JObject bundle = TestDataProvider.GetBundleJsonFromFile(TestDataConstants.EmptyBundleFile);
 
-            var resources = FhirBundleParser.ExtractResourcesFromBundle(bundle);
-            var continuationToken = FhirBundleParser.ExtractContinuationToken(bundle);
+            IEnumerable<JObject> resources = FhirBundleParser.ExtractResourcesFromBundle(bundle);
+            string continuationToken = FhirBundleParser.ExtractContinuationToken(bundle);
 
             Assert.Empty(resources);
             Assert.Null(continuationToken);
@@ -32,8 +32,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         {
             JObject bundle = null;
 
-            var resources = FhirBundleParser.ExtractResourcesFromBundle(bundle);
-            var continuationToken = FhirBundleParser.ExtractContinuationToken(bundle);
+            IEnumerable<JObject> resources = FhirBundleParser.ExtractResourcesFromBundle(bundle);
+            string continuationToken = FhirBundleParser.ExtractContinuationToken(bundle);
             Assert.Empty(resources);
             Assert.Null(continuationToken);
         }
@@ -41,10 +41,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void GivenAValidBundle_WhenParsingBundle_CorrectResultShouldBeReturned()
         {
-            var bundle = TestDataProvider.GetBundleJsonFromFile(TestDataConstants.BundleFile1);
+            JObject bundle = TestDataProvider.GetBundleJsonFromFile(TestDataConstants.BundleFile1);
 
-            var resources = FhirBundleParser.ExtractResourcesFromBundle(bundle);
-            var continuationToken = FhirBundleParser.ExtractContinuationToken(bundle);
+            IEnumerable<JObject> resources = FhirBundleParser.ExtractResourcesFromBundle(bundle);
+            string continuationToken = FhirBundleParser.ExtractContinuationToken(bundle);
 
             Assert.Equal(2, resources.Count());
             Assert.Equal("Y29udGludWF0aW9udG9rZW4=", continuationToken);
@@ -53,14 +53,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void GivenValidOperationOutcomeResources_WhenGetOperationOutcomes_EmptyResultShouldBeReturned()
         {
-            var jObj1 = JObject.Parse("{\"resourceType\":\"OperationOutcome\"}");
-            var jObj2 = JObject.Parse(TestDataProvider.GetBundleFromFile(TestDataConstants.InvalidResponseFile));
-            var input = new List<JObject> { jObj1, jObj2 };
-            var results = FhirBundleParser.GetOperationOutcomes(input);
+            JObject jObj1 = JObject.Parse("{\"resourceType\":\"OperationOutcome\"}");
+            JObject jObj2 = JObject.Parse(TestDataProvider.GetBundleFromFile(TestDataConstants.InvalidResponseFile));
+            List<JObject> input = new List<JObject> { jObj1, jObj2 };
+            IEnumerable<JObject> results = FhirBundleParser.GetOperationOutcomes(input);
             Assert.Equal(2, results.Count());
 
             input.Add(JObject.Parse("{\"resourceType\":\"Patient\"}"));
-            var updatedResults = FhirBundleParser.GetOperationOutcomes(input);
+            IEnumerable<JObject> updatedResults = FhirBundleParser.GetOperationOutcomes(input);
             Assert.Equal(2, updatedResults.Count());
 
             Assert.Equal(results.ToString(), updatedResults.ToString());
@@ -69,8 +69,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void GivenEmptyResources_WhenGetOperationOutcomes_EmptyResultShouldBeReturned()
         {
-            var input = new List<JObject>();
-            var results = FhirBundleParser.GetOperationOutcomes(input);
+            List<JObject> input = new List<JObject>();
+            IEnumerable<JObject> results = FhirBundleParser.GetOperationOutcomes(input);
             Assert.Empty(results);
 
             input.Add(null);
@@ -87,21 +87,21 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void GivenInvalidOperationOutcomeResources_WhenGetOperationOutcomes_EmptyResultShouldBeReturned()
         {
-            var jObj1 = JObject.Parse("{\"a\":1}");
-            var jObj2 = JObject.Parse("{\"resourceType\":\"Patient\"}");
-            var jObj3 = JObject.Parse("{\"resourceType\":\"operationOutcome\"}");
+            JObject jObj1 = JObject.Parse("{\"a\":1}");
+            JObject jObj2 = JObject.Parse("{\"resourceType\":\"Patient\"}");
+            JObject jObj3 = JObject.Parse("{\"resourceType\":\"operationOutcome\"}");
 
-            var input = new List<JObject> { jObj1, jObj2, jObj3 };
-            var results = FhirBundleParser.GetOperationOutcomes(input);
+            List<JObject> input = new List<JObject> { jObj1, jObj2, jObj3 };
+            IEnumerable<JObject> results = FhirBundleParser.GetOperationOutcomes(input);
             Assert.Empty(results);
         }
 
         [Fact]
         public void GivenAValidBundle_WithNoNextLink_WhenParsingBatchData_CorrectResultShouldBeReturned()
         {
-            var bundle = TestDataProvider.GetBundleJsonFromFile(TestDataConstants.BundleFile2);
-            var resources = FhirBundleParser.ExtractResourcesFromBundle(bundle);
-            var continuationToken = FhirBundleParser.ExtractContinuationToken(bundle);
+            JObject bundle = TestDataProvider.GetBundleJsonFromFile(TestDataConstants.BundleFile2);
+            IEnumerable<JObject> resources = FhirBundleParser.ExtractResourcesFromBundle(bundle);
+            string continuationToken = FhirBundleParser.ExtractContinuationToken(bundle);
 
             Assert.Single(resources);
             Assert.Null(continuationToken);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/R4FhirSpecificationProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/R4FhirSpecificationProviderTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Synapse.Common.Logging;
@@ -80,7 +81,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void WhenGetAllResourceTypes_TheResourcesTypeShouldBeReturned()
         {
-            var types = _r4FhirSpecificationProvider.GetAllResourceTypes().ToList();
+            List<string> types = _r4FhirSpecificationProvider.GetAllResourceTypes().ToList();
             Assert.Equal(145, types.Count);
         }
 
@@ -89,7 +90,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [InlineData("Account")]
         public void GivenValidResourceType_WhenCheckIsFhirResourceType_TrueShouldBeReturned(string type)
         {
-            var isValid = _r4FhirSpecificationProvider.IsValidFhirResourceType(type);
+            bool isValid = _r4FhirSpecificationProvider.IsValidFhirResourceType(type);
             Assert.True(isValid);
         }
 
@@ -103,14 +104,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [InlineData("Patient ")]
         public void GivenInvalidResourceType_WhenCheckIsFhirResourceType_FalseShouldBeReturned(string type)
         {
-            var isValid = _r4FhirSpecificationProvider.IsValidFhirResourceType(type);
+            bool isValid = _r4FhirSpecificationProvider.IsValidFhirResourceType(type);
             Assert.False(isValid);
         }
 
         [Fact]
         public void GivenValidCompartmentType_WhenGetCompartmentResourceTypes_ResourceTypesShouldBeReturned()
         {
-            var types = _r4FhirSpecificationProvider.GetCompartmentResourceTypes("Patient");
+            IEnumerable<string> types = _r4FhirSpecificationProvider.GetCompartmentResourceTypes("Patient");
             Assert.Equal(66, types.Count());
         }
 
@@ -136,7 +137,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
             string type,
             int cnt)
         {
-            var parameters = _r4FhirSpecificationProvider.GetSearchParametersByResourceType(type).ToList();
+            List<string> parameters = _r4FhirSpecificationProvider.GetSearchParametersByResourceType(type).ToList();
             Assert.NotEmpty(parameters);
             Assert.Equal(cnt, parameters.Count);
             Assert.Contains("_id", parameters);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/R4FhirSpecificationProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/R4FhirSpecificationProviderTests.cs
@@ -31,9 +31,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
 
         public R4FhirSpecificationProviderTests()
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
 
-            var metadataOptions = new MetadataOptions();
+            MetadataOptions metadataOptions = new MetadataOptions();
             dataClient.Search(metadataOptions)
                 .ReturnsForAnyArgs(x => TestDataProvider.GetBundleFromFile(TestDataConstants.R4MetadataFile));
 
@@ -46,7 +46,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
             Assert.Throws<ArgumentNullException>(
                 () => new R4FhirSpecificationProvider(null, _diagnosticLogger, _nullR4FhirSpecificationProviderLogger));
 
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
 
             Assert.Throws<ArgumentNullException>(
                 () => new R4FhirSpecificationProvider(dataClient, _diagnosticLogger, null));
@@ -55,10 +55,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void GivenBrokenDataClient_WhenInitialize_ExceptionShouldBeThrown()
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
             dataClient.SearchAsync(default).ThrowsForAnyArgs(new FhirSearchException("mockException"));
 
-            var provider = new R4FhirSpecificationProvider(dataClient, _diagnosticLogger, _nullR4FhirSpecificationProviderLogger);
+            R4FhirSpecificationProvider provider = new R4FhirSpecificationProvider(dataClient, _diagnosticLogger, _nullR4FhirSpecificationProviderLogger);
             Assert.Throws<FhirSpecificationProviderException>(
                 () => provider.GetSearchParametersByResourceType("Patient"));
         }
@@ -70,10 +70,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [InlineData("{\"resourceType\": \"CapabilityStatement\",\"rest\": [{\"mode\":\"server\"}]}")]
         public void GivenInvalidMetadata_WhenInitialize_ExceptionShouldBeThrown(string metadataContent)
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
             dataClient.SearchAsync(default).ReturnsForAnyArgs(metadataContent);
 
-            var provider = new R4FhirSpecificationProvider(dataClient, _diagnosticLogger, _nullR4FhirSpecificationProviderLogger);
+            R4FhirSpecificationProvider provider = new R4FhirSpecificationProvider(dataClient, _diagnosticLogger, _nullR4FhirSpecificationProviderLogger);
             Assert.Throws<FhirSpecificationProviderException>(
                 () => provider.GetSearchParametersByResourceType("Patient"));
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/R5FhirSpecificationProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/R5FhirSpecificationProviderTests.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
 
         public R5FhirSpecificationProviderTests()
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
 
-            var metadataOptions = new MetadataOptions();
+            MetadataOptions metadataOptions = new MetadataOptions();
             dataClient.Search(metadataOptions)
                 .ReturnsForAnyArgs(x => TestDataProvider.GetBundleFromFile(TestDataConstants.R5MetadataFile));
 
@@ -45,7 +45,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
             Assert.Throws<ArgumentNullException>(
                 () => new R5FhirSpecificationProvider(null, _diagnosticLogger, _nullR5FhirSpecificationProviderLogger));
 
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
 
             Assert.Throws<ArgumentNullException>(
                 () => new R5FhirSpecificationProvider(dataClient, _diagnosticLogger, null));
@@ -54,10 +54,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void GivenBrokenDataClient_WhenInitialize_ExceptionShouldBeThrown()
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
             dataClient.SearchAsync(default, default).ThrowsForAnyArgs(new FhirSearchException("mockException"));
 
-            var provider = new R5FhirSpecificationProvider(dataClient, _diagnosticLogger, _nullR5FhirSpecificationProviderLogger);
+            R5FhirSpecificationProvider provider = new R5FhirSpecificationProvider(dataClient, _diagnosticLogger, _nullR5FhirSpecificationProviderLogger);
             Assert.Throws<FhirSpecificationProviderException>(
                 () => provider.GetSearchParametersByResourceType("Patient"));
         }
@@ -69,10 +69,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [InlineData("{\"resourceType\": \"CapabilityStatement\",\"rest\": [{\"mode\":\"server\"}]}")]
         public void GivenInvalidMetadata_WhenInitialize_ExceptionShouldBeThrown(string metadataContent)
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
             dataClient.SearchAsync(default, default).ReturnsForAnyArgs(metadataContent);
 
-            var provider = new R5FhirSpecificationProvider(dataClient, _diagnosticLogger, _nullR5FhirSpecificationProviderLogger);
+            R5FhirSpecificationProvider provider = new R5FhirSpecificationProvider(dataClient, _diagnosticLogger, _nullR5FhirSpecificationProviderLogger);
             Assert.Throws<FhirSpecificationProviderException>(
                 () => provider.GetSearchParametersByResourceType("Patient"));
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/R5FhirSpecificationProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Fhir/R5FhirSpecificationProviderTests.cs
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Synapse.Common.Logging;
@@ -79,7 +80,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [Fact]
         public void WhenGetAllResourceTypes_TheResourcesTypeShouldBeReturned()
         {
-            var types = _r5FhirSpecificationProvider.GetAllResourceTypes().ToList();
+            List<string> types = _r5FhirSpecificationProvider.GetAllResourceTypes().ToList();
             Assert.Equal(151, types.Count);
         }
 
@@ -89,7 +90,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [InlineData("EvidenceReport")]
         public void GivenValidResourceType_WhenCheckIsFhirResourceType_TrueShouldBeReturned(string type)
         {
-            var isValid = _r5FhirSpecificationProvider.IsValidFhirResourceType(type);
+            bool isValid = _r5FhirSpecificationProvider.IsValidFhirResourceType(type);
             Assert.True(isValid);
         }
 
@@ -103,14 +104,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
         [InlineData("Patient ")]
         public void GivenInvalidResourceType_WhenCheckIsFhirResourceType_FalseShouldBeReturned(string type)
         {
-            var isValid = _r5FhirSpecificationProvider.IsValidFhirResourceType(type);
+            bool isValid = _r5FhirSpecificationProvider.IsValidFhirResourceType(type);
             Assert.False(isValid);
         }
 
         [Fact]
         public void GivenValidCompartmentType_WhenGetCompartmentResourceTypes_ResourceTypesShouldBeReturned()
         {
-            var types = _r5FhirSpecificationProvider.GetCompartmentResourceTypes("Patient");
+            IEnumerable<string> types = _r5FhirSpecificationProvider.GetCompartmentResourceTypes("Patient");
             Assert.Equal(68, types.Count());
         }
 
@@ -137,7 +138,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Fhir
             string type,
             int cnt)
         {
-            var parameters = _r5FhirSpecificationProvider.GetSearchParametersByResourceType(type).ToList();
+            List<string> parameters = _r5FhirSpecificationProvider.GetSearchParametersByResourceType(type).ToList();
             Assert.NotEmpty(parameters);
             Assert.Equal(cnt, parameters.Count);
             Assert.Contains("_id", parameters);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/AzureTableMetadataStoreTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/AzureTableMetadataStoreTests.cs
@@ -30,10 +30,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenEmptyTable_WhenGetTriggerLeaseEntity_ThenFalseWillBeReturned()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var entity = await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
+                TriggerLeaseEntity entity = await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.Null(entity);
             }
             finally
@@ -45,10 +45,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenEmptyTable_WhenCurrentTriggerEntity_ThenNullWillBeReturned()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var entity = await metadataStore.GetCurrentTriggerEntityAsync(QueueTypeByte, CancellationToken.None);
+                CurrentTriggerEntity entity = await metadataStore.GetCurrentTriggerEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.Null(entity);
             }
             finally
@@ -60,7 +60,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenCurrentTriggerEntity_WhenGetCurrentTriggerEntity_ThenTheEntityShouldBeReturned()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
                 var entity = new CurrentTriggerEntity
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var retrievedEntity = await metadataStore.GetCurrentTriggerEntityAsync(QueueTypeByte, CancellationToken.None);
+                CurrentTriggerEntity retrievedEntity = await metadataStore.GetCurrentTriggerEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.NotNull(retrievedEntity);
                 Assert.Equal(entity.PartitionKey, retrievedEntity.PartitionKey);
                 Assert.Equal(entity.RowKey, retrievedEntity.RowKey);
@@ -92,7 +92,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenEmptyTable_WhenCompartmentInfoEntity_ThenTheExceptionShouldBeThrown()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
                 var exception = await Assert.ThrowsAsync<RequestFailedException>(async () => await metadataStore.GetCompartmentInfoEntityAsync(QueueTypeByte, "fakepatientid", CancellationToken.None));
@@ -107,10 +107,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenCompartmentInfoEntity_WhenGetCompartmentInfoEntity_ThenTheEntityShouldBeReturned()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var patientId = "fakepatientId";
+                string patientId = "fakepatientId";
                 var entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
@@ -121,7 +121,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var retrievedEntity = await metadataStore.GetCompartmentInfoEntityAsync(QueueTypeByte, patientId, CancellationToken.None);
+                CompartmentInfoEntity retrievedEntity = await metadataStore.GetCompartmentInfoEntityAsync(QueueTypeByte, patientId, CancellationToken.None);
                 Assert.NotNull(retrievedEntity);
                 Assert.Equal(entity.PartitionKey, retrievedEntity.PartitionKey);
                 Assert.Equal(entity.RowKey, retrievedEntity.RowKey);
@@ -136,7 +136,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenEmptyTable_WhenAddEntity_ThenTheEntityShouldBeAdded()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
                 var instanceGuid = Guid.NewGuid();
@@ -150,7 +150,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
-                var retrievedEntity =
+                TriggerLeaseEntity retrievedEntity =
                     await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.NotNull(retrievedEntity);
                 Assert.Equal(entity.PartitionKey, retrievedEntity.PartitionKey);
@@ -166,7 +166,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenExistingEntity_WhenAddSameEntityAgain_ThenFalseShouldBeReturned()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
                 var instanceGuid = Guid.NewGuid();
@@ -202,7 +202,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenExistingEntity_WhenUpdateEntity_ThenTheEntityShouldBeUpdated()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
                 var instanceGuid = Guid.NewGuid();
@@ -216,7 +216,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
-                var retrievedEntity =
+                TriggerLeaseEntity retrievedEntity =
                     await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.NotNull(retrievedEntity);
                 Assert.Equal(instanceGuid, retrievedEntity.WorkingInstanceGuid);
@@ -225,7 +225,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 retrievedEntity.HeartbeatDateTime = DateTimeOffset.UtcNow;
                 isSucceeded = await metadataStore.TryUpdateEntityAsync(retrievedEntity);
                 Assert.True(isSucceeded);
-                var retrievedEntity2 =
+                TriggerLeaseEntity retrievedEntity2 =
                     await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.NotNull(retrievedEntity2);
                 Assert.Equal(instanceGuid2, retrievedEntity2.WorkingInstanceGuid);
@@ -240,7 +240,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenOldEntity_WhenUpdateEntity_ThenFalseShouldBeReturned()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
                 var instanceGuid = Guid.NewGuid();
@@ -254,7 +254,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
-                var retrievedEntity =
+                TriggerLeaseEntity retrievedEntity =
                     await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.NotNull(retrievedEntity);
                 Assert.Equal(instanceGuid, retrievedEntity.WorkingInstanceGuid);
@@ -263,7 +263,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 retrievedEntity.HeartbeatDateTime = DateTimeOffset.UtcNow;
                 isSucceeded = await metadataStore.TryUpdateEntityAsync(retrievedEntity);
                 Assert.True(isSucceeded);
-                var retrievedEntity2 =
+                TriggerLeaseEntity retrievedEntity2 =
                     await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.NotNull(retrievedEntity2);
                 Assert.Equal(instanceGuid2, retrievedEntity2.WorkingInstanceGuid);
@@ -284,10 +284,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenCompartmentInfoEntities_WhenGetPatientVersionsByPatientHashList_ThenTheResultShouldBeReturned()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var patientId1 = "patientId1";
+                string patientId1 = "patientId1";
                 var entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
@@ -298,7 +298,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var patientId2 = "patientId2";
+                string patientId2 = "patientId2";
                 entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
@@ -309,9 +309,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var patientHashList = new List<string>
+                List<string> patientHashList = new List<string>
                     { TableKeyProvider.CompartmentRowKey(patientId1) };
-                var patientVersions = await metadataStore.GetPatientVersionsAsync(QueueTypeByte, patientHashList, CancellationToken.None);
+                Dictionary<string, long> patientVersions = await metadataStore.GetPatientVersionsAsync(QueueTypeByte, patientHashList, CancellationToken.None);
                 Assert.Single(patientVersions);
                 Assert.True(patientVersions.ContainsKey(TableKeyProvider.CompartmentRowKey(patientId1)));
                 Assert.Equal(1, patientVersions[TableKeyProvider.CompartmentRowKey(patientId1)]);
@@ -325,10 +325,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenCompartmentInfoEntities_WhenGetPatientVersions_ThenTheResultShouldBeReturned()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var patientId1 = "patientId1";
+                string patientId1 = "patientId1";
                 var entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
@@ -339,7 +339,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var patientId2 = "patientId2";
+                string patientId2 = "patientId2";
                 entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
@@ -350,7 +350,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var patientVersions = await metadataStore.GetPatientVersionsAsync(QueueTypeByte,  CancellationToken.None);
+                Dictionary<string, long> patientVersions = await metadataStore.GetPatientVersionsAsync(QueueTypeByte,  CancellationToken.None);
                 Assert.Equal(2, patientVersions.Count);
                 Assert.True(patientVersions.ContainsKey(TableKeyProvider.CompartmentRowKey(patientId1)));
                 Assert.True(patientVersions.ContainsKey(TableKeyProvider.CompartmentRowKey(patientId1)));
@@ -366,10 +366,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         [Fact]
         public async Task GivenCompartmentInfoEntities_WhenUpdateGetPatientVersions_ThenTheEntitiesShouldBeUpdated()
         {
-            var metadataStore = CreateUniqueMetadataStore();
+            IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var patientId1 = "patientId1";
+                string patientId1 = "patientId1";
                 var entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
@@ -380,7 +380,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var patientId2 = "patientId2";
+                string patientId2 = "patientId2";
                 entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
@@ -391,10 +391,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var updatedPatientVersions = new Dictionary<string, long> { { TableKeyProvider.CompartmentRowKey(patientId1), 2 } };
+                Dictionary<string, long> updatedPatientVersions = new Dictionary<string, long> { { TableKeyProvider.CompartmentRowKey(patientId1), 2 } };
                 await metadataStore.UpdatePatientVersionsAsync(QueueTypeByte, updatedPatientVersions);
 
-                var patientVersions = await metadataStore.GetPatientVersionsAsync(QueueTypeByte, CancellationToken.None);
+                Dictionary<string, long> patientVersions = await metadataStore.GetPatientVersionsAsync(QueueTypeByte, CancellationToken.None);
                 Assert.Equal(2, patientVersions.Count);
                 Assert.True(patientVersions.ContainsKey(TableKeyProvider.CompartmentRowKey(patientId1)));
                 Assert.True(patientVersions.ContainsKey(TableKeyProvider.CompartmentRowKey(patientId1)));
@@ -409,8 +409,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private IMetadataStore CreateUniqueMetadataStore()
         {
-            var uniqueName = Guid.NewGuid().ToString("N");
-            var jobConfig = Options.Create(new JobConfiguration
+            string uniqueName = Guid.NewGuid().ToString("N");
+            IOptions<JobConfiguration> jobConfig = Options.Create(new JobConfiguration
             {
                 JobInfoTableName = $"jobinfotable{uniqueName}",
                 MetadataTableName = $"metadatatable{uniqueName}",

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/AzureTableMetadataStoreTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/AzureTableMetadataStoreTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var entity = new CurrentTriggerEntity
+                CurrentTriggerEntity entity = new CurrentTriggerEntity
                 {
                     PartitionKey = TableKeyProvider.TriggerPartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.TriggerPartitionKey(QueueTypeByte),
@@ -95,7 +95,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var exception = await Assert.ThrowsAsync<RequestFailedException>(async () => await metadataStore.GetCompartmentInfoEntityAsync(QueueTypeByte, "fakepatientid", CancellationToken.None));
+                RequestFailedException exception = await Assert.ThrowsAsync<RequestFailedException>(async () => await metadataStore.GetCompartmentInfoEntityAsync(QueueTypeByte, "fakepatientid", CancellationToken.None));
                 Assert.Equal("ResourceNotFound", exception.ErrorCode);
             }
             finally
@@ -111,7 +111,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             try
             {
                 string patientId = "fakepatientId";
-                var entity = new CompartmentInfoEntity
+                CompartmentInfoEntity entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.CompartmentRowKey(patientId),
@@ -139,8 +139,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var instanceGuid = Guid.NewGuid();
-                var entity = new TriggerLeaseEntity
+                Guid instanceGuid = Guid.NewGuid();
+                TriggerLeaseEntity entity = new TriggerLeaseEntity
                 {
                     PartitionKey = TableKeyProvider.LeasePartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.LeaseRowKey(QueueTypeByte),
@@ -169,8 +169,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var instanceGuid = Guid.NewGuid();
-                var entity = new TriggerLeaseEntity
+                Guid instanceGuid = Guid.NewGuid();
+                TriggerLeaseEntity entity = new TriggerLeaseEntity
                 {
                     PartitionKey = TableKeyProvider.LeasePartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.LeaseRowKey(QueueTypeByte),
@@ -181,8 +181,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 bool isSucceeded = await metadataStore.TryAddEntityAsync(entity);
                 Assert.True(isSucceeded);
 
-                var instanceGuid2 = Guid.NewGuid();
-                var entity2 = new TriggerLeaseEntity
+                Guid instanceGuid2 = Guid.NewGuid();
+                TriggerLeaseEntity entity2 = new TriggerLeaseEntity
                 {
                     PartitionKey = TableKeyProvider.LeasePartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.LeaseRowKey(QueueTypeByte),
@@ -205,8 +205,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var instanceGuid = Guid.NewGuid();
-                var entity = new TriggerLeaseEntity
+                Guid instanceGuid = Guid.NewGuid();
+                TriggerLeaseEntity entity = new TriggerLeaseEntity
                 {
                     PartitionKey = TableKeyProvider.LeasePartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.LeaseRowKey(QueueTypeByte),
@@ -220,7 +220,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                     await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.NotNull(retrievedEntity);
                 Assert.Equal(instanceGuid, retrievedEntity.WorkingInstanceGuid);
-                var instanceGuid2 = Guid.NewGuid();
+                Guid instanceGuid2 = Guid.NewGuid();
                 retrievedEntity.WorkingInstanceGuid = instanceGuid2;
                 retrievedEntity.HeartbeatDateTime = DateTimeOffset.UtcNow;
                 isSucceeded = await metadataStore.TryUpdateEntityAsync(retrievedEntity);
@@ -243,8 +243,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             IMetadataStore metadataStore = CreateUniqueMetadataStore();
             try
             {
-                var instanceGuid = Guid.NewGuid();
-                var entity = new TriggerLeaseEntity
+                Guid instanceGuid = Guid.NewGuid();
+                TriggerLeaseEntity entity = new TriggerLeaseEntity
                 {
                     PartitionKey = TableKeyProvider.LeasePartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.LeaseRowKey(QueueTypeByte),
@@ -258,7 +258,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                     await metadataStore.GetTriggerLeaseEntityAsync(QueueTypeByte, CancellationToken.None);
                 Assert.NotNull(retrievedEntity);
                 Assert.Equal(instanceGuid, retrievedEntity.WorkingInstanceGuid);
-                var instanceGuid2 = Guid.NewGuid();
+                Guid instanceGuid2 = Guid.NewGuid();
                 retrievedEntity.WorkingInstanceGuid = instanceGuid2;
                 retrievedEntity.HeartbeatDateTime = DateTimeOffset.UtcNow;
                 isSucceeded = await metadataStore.TryUpdateEntityAsync(retrievedEntity);
@@ -288,7 +288,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             try
             {
                 string patientId1 = "patientId1";
-                var entity = new CompartmentInfoEntity
+                CompartmentInfoEntity entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.CompartmentRowKey(patientId1),
@@ -329,7 +329,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             try
             {
                 string patientId1 = "patientId1";
-                var entity = new CompartmentInfoEntity
+                CompartmentInfoEntity entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.CompartmentRowKey(patientId1),
@@ -370,7 +370,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             try
             {
                 string patientId1 = "patientId1";
-                var entity = new CompartmentInfoEntity
+                CompartmentInfoEntity entity = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey(QueueTypeByte),
                     RowKey = TableKeyProvider.CompartmentRowKey(patientId1),
@@ -418,10 +418,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             });
 
             // Make sure the container is deleted before running the tests
-            var azureTableClientFactory = new AzureTableClientFactory(
+            AzureTableClientFactory azureTableClientFactory = new AzureTableClientFactory(
                 new DefaultTokenCredentialProvider(new NullLogger<DefaultTokenCredentialProvider>()));
 
-            var metadataStore = new AzureTableMetadataStore(azureTableClientFactory, jobConfig, _nullAzureTableMetadataStoreLogger);
+            AzureTableMetadataStore metadataStore = new AzureTableMetadataStore(azureTableClientFactory, jobConfig, _nullAzureTableMetadataStoreLogger);
             Assert.True(metadataStore.IsInitialized());
             return metadataStore;
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/FhirToDataLakeOrchestratorJobTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/FhirToDataLakeOrchestratorJobTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                     patients.Add($"patientId{i}");
                 }
 
-                var previousPatientInfo = new CompartmentInfoEntity
+                CompartmentInfoEntity previousPatientInfo = new CompartmentInfoEntity
                 {
                     PartitionKey = TableKeyProvider.CompartmentPartitionKey((byte)QueueType.FhirToDataLake),
                     RowKey = TableKeyProvider.CompartmentRowKey(patients[0]),
@@ -125,7 +125,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
             string containerName = Guid.NewGuid().ToString("N");
 
-            var blobClient = new InMemoryBlobContainerClient();
+            InMemoryBlobContainerClient blobClient = new InMemoryBlobContainerClient();
 
             FhirToDataLakeOrchestratorJobInputData inputData = GetInputData();
             MockQueueClient queueClient = GetQueueClient();
@@ -139,7 +139,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.Single(jobInfoList);
             JobInfo orchestratorJobInfo = jobInfoList.First();
 
-            var job = new FhirToDataLakeOrchestratorJob(
+            FhirToDataLakeOrchestratorJob job = new FhirToDataLakeOrchestratorJob(
                 orchestratorJobInfo,
                 inputData,
                 new FhirToDataLakeOrchestratorJobResult(),
@@ -154,7 +154,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 _diagnosticLogger,
                 new NullLogger<FhirToDataLakeOrchestratorJob>());
 
-            var retriableJobException = await Assert.ThrowsAsync<RetriableJobException>(async () =>
+            RetriableJobException retriableJobException = await Assert.ThrowsAsync<RetriableJobException>(async () =>
                 await job.ExecuteAsync(progress, CancellationToken.None));
 
             Assert.IsType<FhirSearchException>(retriableJobException.InnerException);
@@ -176,12 +176,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
             string containerName = Guid.NewGuid().ToString("N");
 
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = filterScope,
             };
 
-            var blobClient = new InMemoryBlobContainerClient();
+            InMemoryBlobContainerClient blobClient = new InMemoryBlobContainerClient();
 
             FhirToDataLakeOrchestratorJobInputData inputData = GetInputData();
             MockQueueClient queueClient = GetQueueClient(filterScope);
@@ -195,7 +195,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.Single(jobInfoList);
             JobInfo orchestratorJobInfo = jobInfoList.First();
 
-            var orchestratorJobResult = new FhirToDataLakeOrchestratorJobResult();
+            FhirToDataLakeOrchestratorJobResult orchestratorJobResult = new FhirToDataLakeOrchestratorJobResult();
             bool resumeMode = resumeFrom >= 0;
             for (int i = 0; i < inputFileCount; ++i)
             {
@@ -203,7 +203,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 {
                     if (i <= resumeFrom)
                     {
-                        var processingInput = new FhirToDataLakeProcessingJobInputData()
+                        FhirToDataLakeProcessingJobInputData processingInput = new FhirToDataLakeProcessingJobInputData()
                         {
                             JobType = JobType.Processing,
                             ProcessingJobSequenceId = i,
@@ -215,7 +215,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
                         JobInfo jobInfo = (await queueClient.EnqueueAsync(0, new[] { JsonConvert.SerializeObject(processingInput) }, 1, false, false, CancellationToken.None)).First();
 
-                        var processingResult = new FhirToDataLakeProcessingJobResult
+                        FhirToDataLakeProcessingJobResult processingResult = new FhirToDataLakeProcessingJobResult
                         {
                             SearchCount = new Dictionary<string, int> { { "Patient", 1 } },
                             ProcessedCount = new Dictionary<string, int> { { "Patient", 1 } },
@@ -258,7 +258,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             }
 
             IGroupMemberExtractor groupMemberExtractor = GetGroupMemberExtractor(inputFileCount);
-            var job = new FhirToDataLakeOrchestratorJob(
+            FhirToDataLakeOrchestratorJob job = new FhirToDataLakeOrchestratorJob(
                 orchestratorJobInfo,
                 inputData,
                 orchestratorJobResult,
@@ -277,7 +277,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             };
 
             string resultString = await job.ExecuteAsync(progress, CancellationToken.None);
-            var result = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(resultString);
+            FhirToDataLakeOrchestratorJobResult result = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(resultString);
 
             Assert.NotNull(result);
             Assert.Equal(inputFileCount, result.CreatedJobCount);
@@ -289,7 +289,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.Equal(inputFileCount * 1000L * TBValue, result.ProcessedDataSizeInTotal);
 
             await Task.Delay(TimeSpan.FromMilliseconds(100));
-            var progressForContext = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(progressResult);
+            FhirToDataLakeOrchestratorJobResult progressForContext = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(progressResult);
             Assert.NotNull(progressForContext);
             Assert.Equal(inputFileCount, progressForContext.CreatedJobCount);
             Assert.Empty(progressForContext.RunningJobIds);
@@ -314,7 +314,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static MockQueueClient GetQueueClient(FilterScope filterScope = FilterScope.System)
         {
-            var queueClient = new MockQueueClient
+            MockQueueClient queueClient = new MockQueueClient
             {
                 GetJobByIdFunc = (queueClient, id,  _) =>
                 {
@@ -330,7 +330,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                         return jobInfo;
                     }
 
-                    var processingResult = new FhirToDataLakeProcessingJobResult
+                    FhirToDataLakeProcessingJobResult processingResult = new FhirToDataLakeProcessingJobResult
                     {
                         SearchCount = new Dictionary<string, int> { { "Patient", 1 } },
                         ProcessedCount = new Dictionary<string, int> { { "Patient", 1 } },
@@ -341,7 +341,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
                     if (filterScope == FilterScope.Group)
                     {
-                        var input =
+                        FhirToDataLakeProcessingJobInputData input =
                             JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobInputData>(jobInfo.Definition);
                         foreach (PatientWrapper patientWrapper in input.ToBeProcessedPatients)
                         {
@@ -372,7 +372,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static IFhirDataClient GetBrokenFhirDataClient()
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
             dataClient.SearchAsync(default)
                 .ReturnsForAnyArgs(Task.FromException<string>(new FhirSearchException("fake fhir search exception.")));
             return dataClient;
@@ -380,7 +380,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static IFhirDataClient GetMockFhirDataClient(int count, int resumedFrom)
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
 
             // Get bundle from next link
             List<string> nextBundles = GetSearchBundles(count);
@@ -411,7 +411,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 MetadataTableName = "metadatatable",
                 JobInfoQueueName = "jobinfoqueue",
             });
-            var tableClientFactory = new AzureTableClientFactory(
+            AzureTableClientFactory tableClientFactory = new AzureTableClientFactory(
                 new DefaultTokenCredentialProvider(new NullLogger<DefaultTokenCredentialProvider>()));
 
             IMetadataStore metadataStore = new AzureTableMetadataStore(tableClientFactory, jobConfig, new NullLogger<AzureTableMetadataStore>());
@@ -421,25 +421,25 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static IFhirDataWriter GetDataWriter(string containerName, IAzureBlobContainerClient blobClient)
         {
-            var mockFactory = Substitute.For<IAzureBlobContainerClientFactory>();
+            IAzureBlobContainerClientFactory mockFactory = Substitute.For<IAzureBlobContainerClientFactory>();
             mockFactory.Create(Arg.Any<string>(), Arg.Any<string>()).ReturnsForAnyArgs(blobClient);
 
-            var storageConfig = new DataLakeStoreConfiguration
+            DataLakeStoreConfiguration storageConfig = new DataLakeStoreConfiguration
             {
                 StorageUrl = TestBlobEndpoint,
             };
-            var jobConfig = new JobConfiguration
+            JobConfiguration jobConfig = new JobConfiguration
             {
                 ContainerName = containerName,
             };
 
-            var dataSink = new AzureBlobDataSink(Options.Create(storageConfig), Options.Create(jobConfig));
+            AzureBlobDataSink dataSink = new AzureBlobDataSink(Options.Create(storageConfig), Options.Create(jobConfig));
             return new AzureBlobDataWriter(mockFactory, dataSink, new NullLogger<AzureBlobDataWriter>());
         }
 
         private static IFilterManager GetFilterManager(FilterConfiguration filterConfiguration)
         {
-            var filterManager = Substitute.For<IFilterManager>();
+            IFilterManager filterManager = Substitute.For<IFilterManager>();
             filterManager.GetTypeFiltersAsync(default).Returns(TestResourceTypeFilters);
             filterManager.GetFilterScopeAsync(default).Returns(filterConfiguration.FilterScope);
             filterManager.GetGroupIdAsync(default).Returns(filterConfiguration.GroupId);
@@ -448,7 +448,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static IGroupMemberExtractor GetGroupMemberExtractor(int count)
         {
-            var groupMemberExtractor = Substitute.For<IGroupMemberExtractor>();
+            IGroupMemberExtractor groupMemberExtractor = Substitute.For<IGroupMemberExtractor>();
             HashSet<string> patients = new HashSet<string>();
             for (int i = 0; i < count; i++)
             {
@@ -461,7 +461,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static async Task CreateBlobForProcessingJob(long jobId, DateTime dateTime, bool isCompleted, IAzureBlobContainerClient blobClient)
         {
-            var stream = new MemoryStream();
+            MemoryStream stream = new MemoryStream();
             byte[] bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
             await stream.WriteAsync(bytes, 0, bytes.Length);
             stream.Position = 0;

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/FhirToDataLakeProcessingJobTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/FhirToDataLakeProcessingJobTests.cs
@@ -53,18 +53,18 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
             string containerName = Guid.NewGuid().ToString("N");
 
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = "Patient",
             };
 
-            var blobClient = new InMemoryBlobContainerClient();
+            InMemoryBlobContainerClient blobClient = new InMemoryBlobContainerClient();
 
             FhirToDataLakeProcessingJob job = GetFhirToDataLakeProcessingJob(1L, GetInputData(), TestDataProvider.GetBundleFromFile(TestDataConstants.PatientBundleFile1), containerName, blobClient, filterConfiguration);
 
             string resultString = await job.ExecuteAsync(progress, CancellationToken.None);
-            var result = JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobResult>(resultString);
+            FhirToDataLakeProcessingJobResult result = JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobResult>(resultString);
 
             Assert.NotNull(result);
             Assert.Equal(3, result.SearchCount["Patient"]);
@@ -74,7 +74,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.Equal(3, result.ProcessedCountInTotal);
 
             await Task.Delay(TimeSpan.FromMilliseconds(100));
-            var progressForContext = JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobResult>(progressResult);
+            FhirToDataLakeProcessingJobResult progressForContext = JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobResult>(progressResult);
             Assert.NotNull(progressForContext);
             Assert.Equal(progressForContext.SearchCount["Patient"], result.SearchCount["Patient"]);
             Assert.Equal(progressForContext.ProcessedCount["Patient"], result.ProcessedCount["Patient"]);
@@ -101,13 +101,13 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
             string containerName = Guid.NewGuid().ToString("N");
 
-            var filterConfiguration = new FilterConfiguration
+            FilterConfiguration filterConfiguration = new FilterConfiguration
             {
                 FilterScope = FilterScope.System,
                 RequiredTypes = "Patient",
             };
 
-            var blobClient = new InMemoryBlobContainerClient();
+            InMemoryBlobContainerClient blobClient = new InMemoryBlobContainerClient();
 
             FhirToDataLakeProcessingJob job = GetFhirToDataLakeProcessingJob(1L, GetInputData(), invalidBundle, containerName, blobClient, filterConfiguration);
 
@@ -137,7 +137,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static IFhirDataClient GetMockFhirDataClient(string firstBundle)
         {
-            var dataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient dataClient = Substitute.For<IFhirDataClient>();
 
             // Get bundle from next link
             string nextBundle = TestDataProvider.GetBundleFromFile(TestDataConstants.PatientBundleFile2);
@@ -147,19 +147,19 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static IFhirDataWriter GetDataWriter(string containerName, IAzureBlobContainerClient blobClient)
         {
-            var mockFactory = Substitute.For<IAzureBlobContainerClientFactory>();
+            IAzureBlobContainerClientFactory mockFactory = Substitute.For<IAzureBlobContainerClientFactory>();
             mockFactory.Create(Arg.Any<string>(), Arg.Any<string>()).ReturnsForAnyArgs(blobClient);
 
-            var storageConfig = new DataLakeStoreConfiguration
+            DataLakeStoreConfiguration storageConfig = new DataLakeStoreConfiguration
             {
                 StorageUrl = TestBlobEndpoint,
             };
-            var jobConfig = new JobConfiguration
+            JobConfiguration jobConfig = new JobConfiguration
             {
                 ContainerName = containerName,
             };
 
-            var dataSink = new AzureBlobDataSink(Options.Create(storageConfig), Options.Create(jobConfig));
+            AzureBlobDataSink dataSink = new AzureBlobDataSink(Options.Create(storageConfig), Options.Create(jobConfig));
             return new AzureBlobDataWriter(mockFactory, dataSink, new NullLogger<AzureBlobDataWriter>());
         }
 
@@ -167,11 +167,11 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         {
             IOptions<SchemaConfiguration> schemaConfigurationOption = Options.Create(new SchemaConfiguration());
 
-            var fhirSchemaManager = new FhirParquetSchemaManager(schemaConfigurationOption, ParquetSchemaProviderDelegate, NullLogger<FhirParquetSchemaManager>.Instance);
+            FhirParquetSchemaManager fhirSchemaManager = new FhirParquetSchemaManager(schemaConfigurationOption, ParquetSchemaProviderDelegate, NullLogger<FhirParquetSchemaManager>.Instance);
             IOptions<ArrowConfiguration> arrowConfigurationOptions = Options.Create(new ArrowConfiguration());
 
-            var defaultConverter = new DefaultSchemaConverter(fhirSchemaManager, _diagnosticLogger, NullLogger<DefaultSchemaConverter>.Instance);
-            var fhirConverter = new CustomSchemaConverter(TestUtils.GetMockAcrTemplateProvider(), schemaConfigurationOption, _diagnosticLogger, NullLogger<CustomSchemaConverter>.Instance);
+            DefaultSchemaConverter defaultConverter = new DefaultSchemaConverter(fhirSchemaManager, _diagnosticLogger, NullLogger<DefaultSchemaConverter>.Instance);
+            CustomSchemaConverter fhirConverter = new CustomSchemaConverter(TestUtils.GetMockAcrTemplateProvider(), schemaConfigurationOption, _diagnosticLogger, NullLogger<CustomSchemaConverter>.Instance);
 
             return new ParquetDataProcessor(
                 fhirSchemaManager,
@@ -196,7 +196,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         private static IFilterManager GetFilterManager(FilterConfiguration filterConfiguration)
         {
             filterConfiguration ??= new FilterConfiguration();
-            var filterManager = Substitute.For<IFilterManager>();
+            IFilterManager filterManager = Substitute.For<IFilterManager>();
             filterManager.GetTypeFiltersAsync(default).Returns(TestResourceTypeFilters);
             filterManager.GetFilterScopeAsync(default).Returns(filterConfiguration.FilterScope);
             filterManager.GetGroupIdAsync(default).Returns(filterConfiguration.GroupId);
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static IGroupMemberExtractor GetGroupMemberExtractor()
         {
-            var groupMemberExtractor = Substitute.For<IGroupMemberExtractor>();
+            IGroupMemberExtractor groupMemberExtractor = Substitute.For<IGroupMemberExtractor>();
             HashSet<string> patients = new HashSet<string> { "patientId1", "patientId2" };
             groupMemberExtractor.GetGroupPatientsAsync(default, default, default, default).ReturnsForAnyArgs(patients);
             return groupMemberExtractor;
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private FhirToDataLakeProcessingJobInputData GetInputData()
         {
-            var inputData = new FhirToDataLakeProcessingJobInputData
+            FhirToDataLakeProcessingJobInputData inputData = new FhirToDataLakeProcessingJobInputData
             {
                 JobType = JobType.Processing,
                 TriggerSequenceId = 0L,

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/FhirToDataLakeProcessingJobTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/FhirToDataLakeProcessingJobTests.cs
@@ -46,12 +46,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         public async Task GivenValidDataClient_WhenExecute_ThenTheDataShouldBeSavedToBlob()
         {
             string progressResult = null;
-            var progress = new Progress<string>((r) =>
+            Progress<string> progress = new Progress<string>((r) =>
             {
                 progressResult = r;
             });
 
-            var containerName = Guid.NewGuid().ToString("N");
+            string containerName = Guid.NewGuid().ToString("N");
 
             var filterConfiguration = new FilterConfiguration
             {
@@ -61,9 +61,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
             var blobClient = new InMemoryBlobContainerClient();
 
-            var job = GetFhirToDataLakeProcessingJob(1L, GetInputData(), TestDataProvider.GetBundleFromFile(TestDataConstants.PatientBundleFile1), containerName, blobClient, filterConfiguration);
+            FhirToDataLakeProcessingJob job = GetFhirToDataLakeProcessingJob(1L, GetInputData(), TestDataProvider.GetBundleFromFile(TestDataConstants.PatientBundleFile1), containerName, blobClient, filterConfiguration);
 
-            var resultString = await job.ExecuteAsync(progress, CancellationToken.None);
+            string resultString = await job.ExecuteAsync(progress, CancellationToken.None);
             var result = JsonConvert.DeserializeObject<FhirToDataLakeProcessingJobResult>(resultString);
 
             Assert.NotNull(result);
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.Equal(progressForContext.ProcessedCountInTotal, result.ProcessedCountInTotal);
 
             // verify blob data;
-            var blobs = await blobClient.ListBlobsAsync("staging");
+            IEnumerable<string> blobs = await blobClient.ListBlobsAsync("staging");
             Assert.Single(blobs);
         }
 
@@ -94,12 +94,12 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         public async Task GivenInvalidSearchBundle_WhenExecuteTask_ExceptionShouldBeThrown(string invalidBundle)
         {
             string progressResult = null;
-            var progress = new Progress<string>((r) =>
+            Progress<string> progress = new Progress<string>((r) =>
             {
                 progressResult = r;
             });
 
-            var containerName = Guid.NewGuid().ToString("N");
+            string containerName = Guid.NewGuid().ToString("N");
 
             var filterConfiguration = new FilterConfiguration
             {
@@ -109,7 +109,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
             var blobClient = new InMemoryBlobContainerClient();
 
-            var job = GetFhirToDataLakeProcessingJob(1L, GetInputData(), invalidBundle, containerName, blobClient, filterConfiguration);
+            FhirToDataLakeProcessingJob job = GetFhirToDataLakeProcessingJob(1L, GetInputData(), invalidBundle, containerName, blobClient, filterConfiguration);
 
             await Assert.ThrowsAsync<RetriableJobException>(() => job.ExecuteAsync(progress, CancellationToken.None));
         }
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             var dataClient = Substitute.For<IFhirDataClient>();
 
             // Get bundle from next link
-            var nextBundle = TestDataProvider.GetBundleFromFile(TestDataConstants.PatientBundleFile2);
+            string nextBundle = TestDataProvider.GetBundleFromFile(TestDataConstants.PatientBundleFile2);
             dataClient.SearchAsync(default).ReturnsForAnyArgs(firstBundle, nextBundle);
             return dataClient;
         }
@@ -165,10 +165,10 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static ParquetDataProcessor GetParquetDataProcessor()
         {
-            var schemaConfigurationOption = Options.Create(new SchemaConfiguration());
+            IOptions<SchemaConfiguration> schemaConfigurationOption = Options.Create(new SchemaConfiguration());
 
             var fhirSchemaManager = new FhirParquetSchemaManager(schemaConfigurationOption, ParquetSchemaProviderDelegate, NullLogger<FhirParquetSchemaManager>.Instance);
-            var arrowConfigurationOptions = Options.Create(new ArrowConfiguration());
+            IOptions<ArrowConfiguration> arrowConfigurationOptions = Options.Create(new ArrowConfiguration());
 
             var defaultConverter = new DefaultSchemaConverter(fhirSchemaManager, _diagnosticLogger, NullLogger<DefaultSchemaConverter>.Instance);
             var fhirConverter = new CustomSchemaConverter(TestUtils.GetMockAcrTemplateProvider(), schemaConfigurationOption, _diagnosticLogger, NullLogger<CustomSchemaConverter>.Instance);
@@ -188,7 +188,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
 
         private static IFhirSchemaManager<FhirParquetSchemaNode> GetFhirSchemaManager()
         {
-            var schemaConfigurationOption = Options.Create(new SchemaConfiguration());
+            IOptions<SchemaConfiguration> schemaConfigurationOption = Options.Create(new SchemaConfiguration());
 
             return new FhirParquetSchemaManager(schemaConfigurationOption, ParquetSchemaProviderDelegate, NullLogger<FhirParquetSchemaManager>.Instance);
         }
@@ -206,7 +206,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
         private static IGroupMemberExtractor GetGroupMemberExtractor()
         {
             var groupMemberExtractor = Substitute.For<IGroupMemberExtractor>();
-            var patients = new HashSet<string> { "patientId1", "patientId2" };
+            HashSet<string> patients = new HashSet<string> { "patientId1", "patientId2" };
             groupMemberExtractor.GetGroupPatientsAsync(default, default, default, default).ReturnsForAnyArgs(patients);
             return groupMemberExtractor;
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/InMemoryBlobContainerClient.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/InMemoryBlobContainerClient.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
     public class InMemoryBlobContainerClient : IAzureBlobContainerClient
     {
         private ConcurrentDictionary<string, Stream> _blobStore = new ConcurrentDictionary<string, Stream>();
-        private ConcurrentDictionary<string, Tuple<string, DateTimeOffset>> _blobLeaseStore =
-            new ConcurrentDictionary<string, Tuple<string, DateTimeOffset>>();
+        private ConcurrentDictionary<string, Tuple<string, DateTimeOffset>> _blobLeaseStore = new ConcurrentDictionary<string, Tuple<string, DateTimeOffset>>();
         private readonly object _leaseLock = new object();
 
         public async Task<T> GetValue<T>(string objectName)

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/InMemoryBlobContainerClient.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/InMemoryBlobContainerClient.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             }
 
             stream.Position = 0;
-            using var streamReader = new StreamReader(stream);
+            using StreamReader streamReader = new StreamReader(stream);
             string content = streamReader.ReadToEnd();
             return JsonConvert.DeserializeObject<T>(content);
         }
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 return Task.FromResult(value);
             }
 
-            var valueCopy = new MemoryStream();
+            MemoryStream valueCopy = new MemoryStream();
             value.CopyTo(valueCopy);
             value.Position = 0;
             valueCopy.Position = 0;

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/MockMetadataStore.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/MockMetadataStore.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 return Task.FromResult(false);
             }
 
-            var entity = tableEntity.CloneObject() as ITableEntity;
+            ITableEntity entity = tableEntity.CloneObject() as ITableEntity;
             entity.ETag = new ETag(Guid.NewGuid().ToString());
 
             _entities[key] = entity;
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
                 return Task.FromResult(false);
             }
 
-            var entity = tableEntity.CloneObject() as ITableEntity;
+            ITableEntity entity = tableEntity.CloneObject() as ITableEntity;
             entity.ETag = new ETag(Guid.NewGuid().ToString());
 
             _entities[key] = entity;

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/SchedulerServiceTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/SchedulerServiceTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             _jobConfigOption = Options.Create(jobConfig);
         }
 
-        #region Initialize Test
+        // Initialize Test
         [Fact]
         public void GivenNullInputParameters_WhenInitialize_ExceptionShouldBeThrown()
         {
@@ -112,10 +112,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.Null(exception);
         }
 
-        #endregion
-
-        #region Check Storage
-
+        // Check Storage
         [Fact]
         public async Task GivenUninitializedStorage_WhenRunAsync_WaitUntilStorageInitialized()
         {
@@ -171,9 +168,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             }
         }
 
-        #endregion
-
-        #region Acauire Lease
+        // Acquire Lease
         [Fact]
         public async Task GivenBrokenMetadataStoreThrowExceptionWhenGetTriggerLeaseEntity_WhenTryAcquireLeaseAsync_ThenNoExceptionShouldBeThrown()
         {
@@ -503,10 +498,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.NotEqual(oldGuid, triggerLeaseEntity1.WorkingInstanceGuid);
         }
 
-        #endregion
-
-        #region Renew Lease
-
+        // Renew Lease
         [Fact]
         public async Task GivenLongRunningSchedulerService_WhenRunAsync_ThenTheLeaseShouldBeRenewed()
         {
@@ -589,10 +581,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             await task;
         }
 
-        #endregion
-
-        #region Enqueue Orchestrator Job
-
+        // Enqueue Orchestrator Job
         [Fact]
         public async Task GivenNewJob_WhenRunAsync_ThenTheInitialTriggerEntityShouldBeCreatedAndEnqueueOrchestratorJob()
         {
@@ -797,10 +786,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             await task;
         }
 
-        #endregion
-
-        #region Complete Trigger
-
+        // Complete Trigger
         [Fact]
         public async Task GivenCompletedTrigger_WhenRunAsync_ThenShouldCreateAndEnqueueTheNextTrigger()
         {
@@ -919,10 +905,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.Equal(endTime, currentTriggerEntity.TriggerEndTime);
         }
 
-        #endregion
-
-        #region Functional Test
-
+        // Functional Test
         [Fact]
         public async Task GivenValidTrigger_WhenRunAsync_ThenTheTriggerShouldBeProcessed()
         {
@@ -1214,10 +1197,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.True(triggerLeaseEntity2.HeartbeatDateTime > triggerLeaseEntity.HeartbeatDateTime);
         }
 
-        #endregion
-
-        #region Cancellation Request
-
+        // Cancellation Request
         [Fact]
         public async Task GivenCancelRequest_WhenStartToRun_ThenSchedulerShouldBeCancelledWithoutDelay()
         {
@@ -1371,7 +1351,5 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.True(elapsedSeconds < schedulerService.SchedulerServicePullingIntervalInSeconds);
             Assert.True(elapsedSeconds < schedulerService.SchedulerServiceLeaseRefreshIntervalInSeconds);
         }
-
-        #endregion
     }
 }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Microsoft.Health.Fhir.Synapse.Core.UnitTests.csproj
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Microsoft.Health.Fhir.Synapse.Core.UnitTests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="Microsoft.Health.Parquet" Version="$(ParquetNativeLibVersion)" />
+    <PackageReference Include="Microsoft.Health.Parquet" Version="1.0.0.215" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/TestUtils.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/TestUtils.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
             // to prevent output from being affected by time zone.
             var serializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
 
-            foreach (var line in File.ReadAllLines(filePath))
+            foreach (string line in File.ReadAllLines(filePath))
             {
                 yield return JsonConvert.DeserializeObject<JObject>(line, serializerSettings);
             }
@@ -52,14 +52,14 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
 
         public static IContainerRegistryTemplateProvider GetMockAcrTemplateProvider()
         {
-            var templateContents = Directory.GetFiles(TestCustomizedSchemaDirectoryPath, "*", SearchOption.AllDirectories)
+            Dictionary<string, byte[]> templateContents = Directory.GetFiles(TestCustomizedSchemaDirectoryPath, "*", SearchOption.AllDirectories)
                 .Select(filePath =>
                 {
-                    var templateContent = File.ReadAllBytes(filePath);
+                    byte[] templateContent = File.ReadAllBytes(filePath);
                     return new KeyValuePair<string, byte[]>(Path.GetRelativePath(TestCustomizedSchemaDirectoryPath, filePath), templateContent);
                 }).ToDictionary(x => x.Key, x => x.Value);
 
-            var templateCollection = TemplateLayerParser.ParseToTemplates(templateContents);
+            Dictionary<string, Template> templateCollection = TemplateLayerParser.ParseToTemplates(templateContents);
 
             var templateProvider = Substitute.For<IContainerRegistryTemplateProvider>();
             templateProvider.GetTemplateCollectionAsync(default, default).ReturnsForAnyArgs(new List<Dictionary<string, Template>> { templateCollection });

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/TestUtils.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/TestUtils.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
         {
             // Date formatted strings are not parsed to a date type and are read as strings,
             // to prevent output from being affected by time zone.
-            var serializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
+            JsonSerializerSettings serializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
 
             foreach (string line in File.ReadAllLines(filePath))
             {
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
 
             Dictionary<string, Template> templateCollection = TemplateLayerParser.ParseToTemplates(templateContents);
 
-            var templateProvider = Substitute.For<IContainerRegistryTemplateProvider>();
+            IContainerRegistryTemplateProvider templateProvider = Substitute.For<IContainerRegistryTemplateProvider>();
             templateProvider.GetTemplateCollectionAsync(default, default).ReturnsForAnyArgs(new List<Dictionary<string, Template>> { templateCollection });
             return templateProvider;
         }
@@ -87,7 +87,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests
 
         public static IDataSchemaConverter TestDataSchemaConverterDelegate(string name)
         {
-            var fhirSchemaManagerWithoutCustomizedSchema = new FhirParquetSchemaManager(
+            FhirParquetSchemaManager fhirSchemaManagerWithoutCustomizedSchema = new FhirParquetSchemaManager(
                 Options.Create(new SchemaConfiguration()),
                 TestParquetSchemaProviderDelegate,
                 NullLogger<FhirParquetSchemaManager>.Instance);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/AzureAccessTokenProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/AzureAccessTokenProviderTests.cs
@@ -40,12 +40,12 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [Fact]
         public async Task GivenAResourceUrl_WhenGetAccessToken_CachedAccessTokenWillBeReturnedIfNotExpired()
         {
-            var resourceUrl = "http://test";
+            string resourceUrl = "http://test";
             var accessTokenProvider = new AzureAccessTokenProvider(new MockTimeBasedTokenCredential(), _diagnosticLogger, new NullLogger<AzureAccessTokenProvider>());
 
-            var accessToken = await accessTokenProvider.GetAccessTokenAsync(resourceUrl);
+            string accessToken = await accessTokenProvider.GetAccessTokenAsync(resourceUrl);
             Thread.Sleep(2000);
-            var cachedToken = await accessTokenProvider.GetAccessTokenAsync(resourceUrl);
+            string cachedToken = await accessTokenProvider.GetAccessTokenAsync(resourceUrl);
             Assert.Equal(accessToken, cachedToken);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/AzureAccessTokenProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/AzureAccessTokenProviderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [InlineData("    ")]
         public async Task GivenAnInvalidResourceUrl_WhenGetAccessToken_ArgumentExceptionShouldBeThrown(string resourceUrl)
         {
-            var accessTokenProvider = new AzureAccessTokenProvider(new MockTokenCredential(), _diagnosticLogger, new NullLogger<AzureAccessTokenProvider>());
+            AzureAccessTokenProvider accessTokenProvider = new AzureAccessTokenProvider(new MockTokenCredential(), _diagnosticLogger, new NullLogger<AzureAccessTokenProvider>());
 
             _ = await Assert.ThrowsAsync<ArgumentException>(() => accessTokenProvider.GetAccessTokenAsync(resourceUrl));
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [InlineData(null)]
         public async Task GivenANullResourceUrl_WhenGetAccessToken_ArgumentNullExceptionShouldBeThrown(string resourceUrl)
         {
-            var accessTokenProvider = new AzureAccessTokenProvider(new MockTokenCredential(), _diagnosticLogger, new NullLogger<AzureAccessTokenProvider>());
+            AzureAccessTokenProvider accessTokenProvider = new AzureAccessTokenProvider(new MockTokenCredential(), _diagnosticLogger, new NullLogger<AzureAccessTokenProvider>());
 
             _ = await Assert.ThrowsAsync<ArgumentNullException>(() => accessTokenProvider.GetAccessTokenAsync(resourceUrl));
         }
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         public async Task GivenAResourceUrl_WhenGetAccessToken_CachedAccessTokenWillBeReturnedIfNotExpired()
         {
             string resourceUrl = "http://test";
-            var accessTokenProvider = new AzureAccessTokenProvider(new MockTimeBasedTokenCredential(), _diagnosticLogger, new NullLogger<AzureAccessTokenProvider>());
+            AzureAccessTokenProvider accessTokenProvider = new AzureAccessTokenProvider(new MockTimeBasedTokenCredential(), _diagnosticLogger, new NullLogger<AzureAccessTokenProvider>());
 
             string accessToken = await accessTokenProvider.GetAccessTokenAsync(resourceUrl);
             Thread.Sleep(2000);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/FhirApiDataClientTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/FhirApiDataClientTests.cs
@@ -42,14 +42,14 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
             Assert.Throws<ArgumentNullException>(
                 () => new FhirApiDataClient(null, null, null, null, null));
 
-            var fhirServerConfiguration = new FhirServerConfiguration()
+            FhirServerConfiguration fhirServerConfiguration = new FhirServerConfiguration()
             {
                 ServerUrl = FhirServerUri,
             };
 
-            var dataSource = new FhirApiDataSource(Options.Create(fhirServerConfiguration));
+            FhirApiDataSource dataSource = new FhirApiDataSource(Options.Create(fhirServerConfiguration));
 
-            var httpClient = new HttpClient(new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>()));
+            HttpClient httpClient = new HttpClient(new MockHttpMessageHandler(new Dictionary<string, HttpResponseMessage>()));
 
             Assert.Throws<ArgumentNullException>(
                 () => new FhirApiDataClient(null, httpClient, _mockTokenCredentialProvider, _diagnosticLogger, _nullFhirApiDataClientLogger));
@@ -69,7 +69,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         {
             FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
 
-            var metadataOption = new MetadataOptions();
+            MetadataOptions metadataOption = new MetadataOptions();
             string metaData = client.Search(metadataOption);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.R4MetadataFile), metaData);
@@ -80,7 +80,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         {
             FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
 
-            var metadataOption = new MetadataOptions();
+            MetadataOptions metadataOption = new MetadataOptions();
             string metaData = await client.SearchAsync(metadataOption);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.R4MetadataFile), metaData);
@@ -90,7 +90,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         public void GivenSearchOptionRequiredAccessToken_WhenSearchFhirDataSync_ExceptionShouldBeThrown()
         {
             FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
-            var searchOptions = new BaseSearchOptions("Patient", null);
+            BaseSearchOptions searchOptions = new BaseSearchOptions("Patient", null);
             Assert.Throws<FhirSearchException>(() => client.Search(searchOptions));
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
             };
 
-            var searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
+            BaseSearchOptions searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
             string bundle1 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
@@ -145,7 +145,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
             };
 
-            var searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
+            BaseSearchOptions searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
             string bundle1 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
@@ -165,7 +165,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         public async Task GivenNullQueryParameters_WhenSearchFhirData_CorrectBatchDataShouldBeReturned()
         {
             FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
-            var searchOptions = new BaseSearchOptions(SampleResourceType, null);
+            BaseSearchOptions searchOptions = new BaseSearchOptions(SampleResourceType, null);
             string bundle1 = await client.SearchAsync(searchOptions);
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
         }
@@ -182,9 +182,9 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
                 new (FhirApiConstants.ContinuationKey, string.Empty),
             };
-            var searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
+            BaseSearchOptions searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
 
-            var exception = await Assert.ThrowsAsync<FhirSearchException>(() => client.SearchAsync(searchOptions));
+            FhirSearchException exception = await Assert.ThrowsAsync<FhirSearchException>(() => client.SearchAsync(searchOptions));
             Assert.IsType<HttpRequestException>(exception.InnerException);
         }
 
@@ -198,7 +198,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
                 new (FhirApiConstants.ContinuationKey, string.Empty),
             };
-            var searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
+            BaseSearchOptions searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
 
             await Assert.ThrowsAsync<FhirSearchException>(() => client.SearchAsync(searchOptions));
         }
@@ -208,7 +208,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         {
             FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
 
-            var searchOptions = new ResourceIdSearchOptions("MedicationRequest", "3123", null);
+            ResourceIdSearchOptions searchOptions = new ResourceIdSearchOptions("MedicationRequest", "3123", null);
             string bundle1 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
@@ -223,7 +223,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
                 new (FhirApiConstants.LastUpdatedKey, $"ge{DateTimeOffset.Parse(SampleStartTime).ToInstantString()}"),
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
             };
-            var searchOptions = new CompartmentSearchOptions("Patient", "347", "*", queryParameters);
+            CompartmentSearchOptions searchOptions = new CompartmentSearchOptions("Patient", "347", "*", queryParameters);
             string bundle1 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
@@ -261,22 +261,22 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
 
             dataSource ??= CreateFhirApiDataSource(fhirServerUrl, AuthenticationType.ManagedIdentity);
 
-            var httpClient = new HttpClient(new MockHttpMessageHandler(requestMap));
+            HttpClient httpClient = new HttpClient(new MockHttpMessageHandler(requestMap));
 
-            var dataClient = new FhirApiDataClient(dataSource, httpClient, mockProvider, _diagnosticLogger, _nullFhirApiDataClientLogger);
+            FhirApiDataClient dataClient = new FhirApiDataClient(dataSource, httpClient, mockProvider, _diagnosticLogger, _nullFhirApiDataClientLogger);
             return dataClient;
         }
 
         private IFhirApiDataSource CreateFhirApiDataSource(string fhirServerUrl, AuthenticationType authenticationType)
         {
-            var fhirServerConfig = new FhirServerConfiguration
+            FhirServerConfiguration fhirServerConfig = new FhirServerConfiguration
             {
                 ServerUrl = fhirServerUrl,
                 Authentication = authenticationType,
             };
 
             IOptions<FhirServerConfiguration> fhirServerOption = Options.Create(fhirServerConfig);
-            var dataSource = new FhirApiDataSource(fhirServerOption);
+            FhirApiDataSource dataSource = new FhirApiDataSource(fhirServerOption);
 
             return dataSource;
         }
@@ -285,7 +285,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
             string body,
             HttpStatusCode code = HttpStatusCode.OK)
         {
-            var response = new HttpResponseMessage(code);
+            HttpResponseMessage response = new HttpResponseMessage(code);
             response.Content = new StringContent(body);
             return response;
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/FhirApiDataClientTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/FhirApiDataClientTests.cs
@@ -67,10 +67,10 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [Fact]
         public void GivenAValidDataClient_WhenGetMetadataSync_MetadataBundleShouldBeReturned()
         {
-            var client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
+            FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
 
             var metadataOption = new MetadataOptions();
-            var metaData = client.Search(metadataOption);
+            string metaData = client.Search(metadataOption);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.R4MetadataFile), metaData);
         }
@@ -78,10 +78,10 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [Fact]
         public async Task GivenAValidDataClient_WhenGetMetadataASync_MetadataBundleShouldBeReturned()
         {
-            var client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
+            FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
 
             var metadataOption = new MetadataOptions();
-            var metaData = await client.SearchAsync(metadataOption);
+            string metaData = await client.SearchAsync(metadataOption);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.R4MetadataFile), metaData);
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [Fact]
         public void GivenSearchOptionRequiredAccessToken_WhenSearchFhirDataSync_ExceptionShouldBeThrown()
         {
-            var client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
+            FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
             var searchOptions = new BaseSearchOptions("Patient", null);
             Assert.Throws<FhirSearchException>(() => client.Search(searchOptions));
         }
@@ -103,27 +103,27 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [InlineData("https://example.com/a/b/c/")]
         public async Task GivenAValidSearchOption_WhenSearchFhirData_CorrectBatchDataShouldBeReturned(string serverUrl)
         {
-            var client = CreateDataClient(serverUrl, _mockTokenCredentialProvider);
+            FhirApiDataClient client = CreateDataClient(serverUrl, _mockTokenCredentialProvider);
 
             // First batch
-            var queryParameters = new List<KeyValuePair<string, string>>
+            List<KeyValuePair<string, string>> queryParameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.LastUpdatedKey, $"ge{DateTimeOffset.Parse(SampleStartTime).ToInstantString()}"),
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
             };
 
             var searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
-            var bundle1 = await client.SearchAsync(searchOptions);
+            string bundle1 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
 
             // Get continuation token
             JObject bundleJObject = JObject.Parse(bundle1);
-            var continuationToken = FhirBundleParser.ExtractContinuationToken(bundleJObject);
+            string continuationToken = FhirBundleParser.ExtractContinuationToken(bundleJObject);
 
             searchOptions.QueryParameters.Add(new KeyValuePair<string, string>(FhirApiConstants.ContinuationKey, continuationToken));
 
-            var bundle2 = await client.SearchAsync(searchOptions);
+            string bundle2 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile2), bundle2);
         }
@@ -135,28 +135,28 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [InlineData("https://example.com/#/")]
         public async Task GivenServerUrlWithPoundKey_WhenSearchFhirData_CorrectBatchDataShouldBeReturned(string serverUrl)
         {
-            var datasource = CreateFhirApiDataSource(serverUrl, AuthenticationType.ManagedIdentity);
-            var client = CreateDataClient("https://example.com", _mockTokenCredentialProvider, datasource);
+            IFhirApiDataSource datasource = CreateFhirApiDataSource(serverUrl, AuthenticationType.ManagedIdentity);
+            FhirApiDataClient client = CreateDataClient("https://example.com", _mockTokenCredentialProvider, datasource);
 
             // First batch
-            var queryParameters = new List<KeyValuePair<string, string>>
+            List<KeyValuePair<string, string>> queryParameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.LastUpdatedKey, $"ge{DateTimeOffset.Parse(SampleStartTime).ToInstantString()}"),
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
             };
 
             var searchOptions = new BaseSearchOptions(SampleResourceType, queryParameters);
-            var bundle1 = await client.SearchAsync(searchOptions);
+            string bundle1 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
 
             // Get continuation token
             JObject bundleJObject = JObject.Parse(bundle1);
-            var continuationToken = FhirBundleParser.ExtractContinuationToken(bundleJObject);
+            string continuationToken = FhirBundleParser.ExtractContinuationToken(bundleJObject);
 
             searchOptions.QueryParameters.Add(new KeyValuePair<string, string>(FhirApiConstants.ContinuationKey, continuationToken));
 
-            var bundle2 = await client.SearchAsync(searchOptions);
+            string bundle2 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile2), bundle2);
         }
@@ -164,9 +164,9 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [Fact]
         public async Task GivenNullQueryParameters_WhenSearchFhirData_CorrectBatchDataShouldBeReturned()
         {
-            var client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
+            FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
             var searchOptions = new BaseSearchOptions(SampleResourceType, null);
-            var bundle1 = await client.SearchAsync(searchOptions);
+            string bundle1 = await client.SearchAsync(searchOptions);
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
         }
 
@@ -175,8 +175,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         {
             // A different start time will result in an unknown url to mock http handler.
             // An HttpRequestException will throw during search.
-            var client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
-            var queryParameters = new List<KeyValuePair<string, string>>
+            FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
+            List<KeyValuePair<string, string>> queryParameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.LastUpdatedKey, $"ge{DateTimeOffset.Parse("2021-07-07T12:00:00+08:00").ToInstantString()}"),
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
@@ -191,8 +191,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [Fact]
         public async Task GivenAnInvalidTokenProvider_WhenSearchFhirData_ExceptionShouldBeThrown()
         {
-            var client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
-            var queryParameters = new List<KeyValuePair<string, string>>
+            FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
+            List<KeyValuePair<string, string>> queryParameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.LastUpdatedKey, $"ge{DateTimeOffset.Parse(SampleStartTime).ToInstantString()}"),
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
@@ -206,10 +206,10 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [Fact]
         public async Task GivenAValidResourceIdSearchOption_WhenSearchFhirData_CorrectBatchDataShouldBeReturned()
         {
-            var client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
+            FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
 
             var searchOptions = new ResourceIdSearchOptions("MedicationRequest", "3123", null);
-            var bundle1 = await client.SearchAsync(searchOptions);
+            string bundle1 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
         }
@@ -217,14 +217,14 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [Fact]
         public async Task GivenAValidCompartmentSearchOption_WhenSearchFhirData_CorrectBatchDataShouldBeReturned()
         {
-            var client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
-            var queryParameters = new List<KeyValuePair<string, string>>
+            FhirApiDataClient client = CreateDataClient(FhirServerUri, _mockTokenCredentialProvider);
+            List<KeyValuePair<string, string>> queryParameters = new List<KeyValuePair<string, string>>
             {
                 new (FhirApiConstants.LastUpdatedKey, $"ge{DateTimeOffset.Parse(SampleStartTime).ToInstantString()}"),
                 new (FhirApiConstants.LastUpdatedKey, $"lt{DateTimeOffset.Parse(SampleEndTime).ToInstantString()}"),
             };
             var searchOptions = new CompartmentSearchOptions("Patient", "347", "*", queryParameters);
-            var bundle1 = await client.SearchAsync(searchOptions);
+            string bundle1 = await client.SearchAsync(searchOptions);
 
             Assert.Equal(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1), bundle1);
         }
@@ -232,8 +232,8 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         private FhirApiDataClient CreateDataClient(string fhirServerUrl, ITokenCredentialProvider mockProvider, IFhirApiDataSource dataSource = null)
         {
             // Set up http client.
-            var comparer = StringComparer.OrdinalIgnoreCase;
-            var requestMap = new Dictionary<string, HttpResponseMessage>(comparer);
+            StringComparer comparer = StringComparer.OrdinalIgnoreCase;
+            Dictionary<string, HttpResponseMessage> requestMap = new Dictionary<string, HttpResponseMessage>(comparer);
             requestMap.Add(
                 $"{fhirServerUrl.TrimEnd('/')}/Patient?_lastUpdated=ge2021-08-01T12%3A00%3A00%2b08%3a00&_lastUpdated=lt2021-08-09T12%3A40%3A59%2b08%3a00&_count=1000",
                 CreateResponseMessage(TestDataProvider.GetBundleFromFile(TestDataConstants.BundleFile1)));
@@ -275,7 +275,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
                 Authentication = authenticationType,
             };
 
-            var fhirServerOption = Options.Create(fhirServerConfig);
+            IOptions<FhirServerConfiguration> fhirServerOption = Options.Create(fhirServerConfig);
             var dataSource = new FhirApiDataSource(fhirServerOption);
 
             return dataSource;

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/FhirApiDataSourceTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/FhirApiDataSourceTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         public void GivenNullServerUrl_WhenInitialize_ArgumentNullExceptionShouldBeThrown()
         {
             // ServerUrl is string.empty
-            var fhirServerConfig = new FhirServerConfiguration
+            FhirServerConfiguration fhirServerConfig = new FhirServerConfiguration
             {
                 ServerUrl = null,
             };
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         public void GivenEmptyServerUrl_WhenInitialize_ArgumentExceptionShouldBeThrown()
         {
             // ServerUrl is string.empty
-            var fhirServerConfig = new FhirServerConfiguration();
+            FhirServerConfiguration fhirServerConfig = new FhirServerConfiguration();
             Assert.Throws<ArgumentException>(() => new FhirApiDataSource(Options.Create(fhirServerConfig)));
 
             fhirServerConfig.ServerUrl = string.Empty;
@@ -47,11 +47,11 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
         [InlineData("https://example.com/", "https://example.com/")]
         public void GivenServerUrl_WhenInitialize_ServerUrlShouldBeEndsWithSlash(string serverUrl, string expectedServerUrl)
         {
-            var fhirServerConfig = new FhirServerConfiguration
+            FhirServerConfiguration fhirServerConfig = new FhirServerConfiguration
             {
                 ServerUrl = serverUrl,
             };
-            var dataSource = new FhirApiDataSource(Options.Create(fhirServerConfig));
+            FhirApiDataSource dataSource = new FhirApiDataSource(Options.Create(fhirServerConfig));
 
             Assert.Equal(expectedServerUrl, dataSource.FhirServerUrl);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/MockTimeBasedTokenCredential.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Api/MockTimeBasedTokenCredential.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Api
 
         public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
         {
-            var time = DateTimeOffset.Now.ToString();
+            string time = DateTimeOffset.Now.ToString();
             return ValueTask.FromResult(new AccessToken(TestDataConstants.TestAccessToken + time, DateTimeOffset.Now.AddMinutes(5.1)));
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Extensions/DateTimeOffsetExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Extensions/DateTimeOffsetExtensionsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Extensions
             DateTimeOffset dateTimeOffset,
             string expectedInstantValue)
         {
-            var instantValue = dateTimeOffset.ToInstantString();
+            string instantValue = dateTimeOffset.ToInstantString();
             Assert.Equal(expectedInstantValue, instantValue);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Extensions/UriExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Extensions/UriExtensionsTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Extensions
             string expectedUriValue)
         {
             var uri = new Uri(uriValue);
-            var newUri = uri.AddQueryString(parameters);
+            Uri newUri = uri.AddQueryString(parameters);
             Assert.Equal(expectedUriValue, newUri.ToString());
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Extensions/UriExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/Extensions/UriExtensionsTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests.Extensions
             IEnumerable<KeyValuePair<string, string>> parameters,
             string expectedUriValue)
         {
-            var uri = new Uri(uriValue);
+            Uri uri = new Uri(uriValue);
             Uri newUri = uri.AddQueryString(parameters);
             Assert.Equal(expectedUriValue, newUri.ToString());
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/MockHttpMessageHandler.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/MockHttpMessageHandler.cs
@@ -30,14 +30,14 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests
 
             if (request.RequestUri.AbsolutePath != "/metadata")
             {
-                var accessToken = request.Headers.Authorization.Parameter;
+                string accessToken = request.Headers.Authorization.Parameter;
                 if (!string.Equals(accessToken, TestDataConstants.TestAccessToken))
                 {
                     return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized));
                 }
             }
 
-            var urlKey = request.RequestUri.ToString();
+            string urlKey = request.RequestUri.ToString();
             if (_sampleRequests.ContainsKey(urlKey))
             {
                 return Task.FromResult(_sampleRequests[urlKey]);
@@ -50,7 +50,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests
         {
             if (request.RequestUri != null)
             {
-                var urlKey = request.RequestUri.ToString();
+                string urlKey = request.RequestUri.ToString();
                 if (_sampleRequests.ContainsKey(urlKey))
                 {
                     return _sampleRequests[urlKey];

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/TestDataProvider.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/TestDataProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests
 
         public static ITypedElement GetBundleElementFromFile(string filePath)
         {
-            var bundleContent = GetBundleFromFile(filePath);
+            string bundleContent = GetBundleFromFile(filePath);
 
             var fhirConfiguration = new FhirServerConfiguration()
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests
 
         public static JObject GetBundleJsonFromFile(string filePath)
         {
-            var bundleContent = GetBundleFromFile(filePath);
+            string bundleContent = GetBundleFromFile(filePath);
 
             return JObject.Parse(bundleContent);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/TestDataProvider.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataClient.UnitTests/TestDataProvider.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.UnitTests
         {
             string bundleContent = GetBundleFromFile(filePath);
 
-            var fhirConfiguration = new FhirServerConfiguration()
+            FhirServerConfiguration fhirConfiguration = new FhirServerConfiguration()
             {
                 Version = FhirVersion.R4,
             };
-            var fhirSerializer = new FhirSerializer(Options.Create(fhirConfiguration));
+            FhirSerializer fhirSerializer = new FhirSerializer(Options.Create(fhirConfiguration));
 
             return fhirSerializer.DeserializeToElement(bundleContent);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/Azure/AzureBlobContainerClientTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/Azure/AzureBlobContainerClientTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Files.DataLake.Models;
@@ -30,12 +31,12 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public void CreateBlobProvider_ContainerShouldBeCreated()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             // The container doesn't exist at the beginning
             var blobServiceClient = new BlobServiceClient(ConnectionString);
 
-            var container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
             Assert.False(container.Exists());
 
             _ = GetTestBlobProvider(ConnectionString, uniqueContainerName);
@@ -53,12 +54,12 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public void CreateBlobProvider_WhenContainerExists_NoExceptionshouldBeThrown()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             // The container doesn't exist at the beginning
             var blobServiceClient = new BlobServiceClient(ConnectionString);
 
-            var container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
             Assert.False(container.Exists());
 
             // create the container
@@ -80,12 +81,12 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public void CreateTwoBlobProviders_NoExceptionshouldBeThrown()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             // The container doesn't exist at the beginning
             var blobServiceClient = new BlobServiceClient(ConnectionString);
 
-            var container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
             Assert.False(container.Exists());
 
             _ = GetTestBlobProvider(ConnectionString, uniqueContainerName);
@@ -108,27 +109,27 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public void GivenInvalidConnectionString_WhenCreateBlobProvider_ExceptionShouldBeThrown()
         {
-            var errorFormatConncetionString = "invalidstring";
+            string errorFormatConncetionString = "invalidstring";
             Assert.Throws<FormatException>(() => GetTestBlobProvider(errorFormatConncetionString, errorFormatConncetionString));
 
-            var emptyConncetionString = string.Empty;
+            string emptyConncetionString = string.Empty;
             Assert.Throws<ArgumentNullException>(() => GetTestBlobProvider(emptyConncetionString, emptyConncetionString));
 
-            var invalidAccountConncetionString = "DefaultEndpointsProtocol=https;AccountName=fakeaccountname;AccountKey=nbmHd6Y4U3qVgko7VFeFJEfHjX6dNFHUrqT+Kr0fXjwrEIDIv189v+iOljnQ1IYYK95Q2DoPK9KoDyy/T3yt3Q==;EndpointSuffix=core.windows.net";
+            string invalidAccountConncetionString = "DefaultEndpointsProtocol=https;AccountName=fakeaccountname;AccountKey=nbmHd6Y4U3qVgko7VFeFJEfHjX6dNFHUrqT+Kr0fXjwrEIDIv189v+iOljnQ1IYYK95Q2DoPK9KoDyy/T3yt3Q==;EndpointSuffix=core.windows.net";
             Assert.Throws<AzureBlobOperationFailedException>(() => GetTestBlobProvider(invalidAccountConncetionString, invalidAccountConncetionString));
         }
 
         [Fact]
         public void GivenEmptyContainerName_WhenCreateBlobProvider_ExceptionShouldBeThrown()
         {
-            var emptyConatinerName = string.Empty;
+            string emptyConatinerName = string.Empty;
             Assert.Throws<AzureBlobOperationFailedException>(() => GetTestBlobProvider(ConnectionString, emptyConatinerName));
         }
 
         [Fact]
         public async void AccessBlobProvider_WhenContainerNoExists_ExceptionShouldBeThrown()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
@@ -163,26 +164,26 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void DeleteExistingBlob_TrueShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             Assert.False(await blobClient.ExistsAsync());
 
             // create a new blob
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("example")))
             {
-                var result = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
+                bool result = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
 
                 Assert.True(result);
                 Assert.True(await blobClient.ExistsAsync());
             }
 
             // delete the blob
-            var isDeleted = await blobProvider.DeleteBlobAsync(blobName, cancellationToken: CancellationToken.None);
+            bool isDeleted = await blobProvider.DeleteBlobAsync(blobName, cancellationToken: CancellationToken.None);
 
             Assert.True(isDeleted);
             Assert.False(await blobClient.ExistsAsync());
@@ -199,17 +200,17 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void DeleteNoExistingBlob_FalseShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             Assert.False(await blobClient.ExistsAsync());
 
             // delete the blob
-            var isDeleted = await blobProvider.DeleteBlobAsync(blobName, cancellationToken: CancellationToken.None);
+            bool isDeleted = await blobProvider.DeleteBlobAsync(blobName, cancellationToken: CancellationToken.None);
 
             Assert.False(isDeleted);
             Assert.False(await blobClient.ExistsAsync());
@@ -220,20 +221,20 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void CreateNewBlobTwice_FalseShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
             Assert.False(await blobClient.ExistsAsync());
 
             // create a new blob
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("example")))
             {
-                var isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
+                bool isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
                 Assert.True(isCreated);
                 Assert.True(await blobClient.ExistsAsync());
             }
@@ -241,7 +242,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             // create the blob again
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("new example")))
             {
-                var isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
+                bool isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
                 Assert.False(isCreated);
                 Assert.True(await blobClient.ExistsAsync());
             }
@@ -252,26 +253,26 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void CreateDeletedBlob_TrueShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
             Assert.False(await blobClient.ExistsAsync());
 
             // create a new blob
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("example")))
             {
-                var isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
+                bool isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
                 Assert.True(isCreated);
                 Assert.True(await blobClient.ExistsAsync());
             }
 
             // delete the blob
-            var isDeleted = await blobProvider.DeleteBlobAsync(blobName, cancellationToken: CancellationToken.None);
+            bool isDeleted = await blobProvider.DeleteBlobAsync(blobName, cancellationToken: CancellationToken.None);
 
             Assert.True(isDeleted);
             Assert.False(await blobClient.ExistsAsync());
@@ -279,7 +280,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             // create the blob again
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes("new example")))
             {
-                var isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
+                bool isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
                 Assert.True(isCreated);
                 Assert.True(await blobClient.ExistsAsync());
             }
@@ -290,13 +291,13 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void CreateLargeNewBlobTwice_TrueShouldReturnForTheFirstCompleted_And_FalseShouldReturnForTheSecondOne()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
 
             using MemoryStream sourceStream = new MemoryStream();
@@ -314,11 +315,11 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             Assert.False(await blobClient.ExistsAsync());
 
-            var task_1 = blobProvider.CreateBlobAsync(blobName, sourceStream, CancellationToken.None);
-            var task_2 = blobProvider.CreateBlobAsync(blobName, sourceStream, CancellationToken.None);
+            Task<bool> task_1 = blobProvider.CreateBlobAsync(blobName, sourceStream, CancellationToken.None);
+            Task<bool> task_2 = blobProvider.CreateBlobAsync(blobName, sourceStream, CancellationToken.None);
 
-            var isCreated_1 = await task_1;
-            var isCreated_2 = await task_2;
+            bool isCreated_1 = await task_1;
+            bool isCreated_2 = await task_2;
             Assert.True(isCreated_1 ^ isCreated_2);
 
             await blobContainerClient.DeleteAsync();
@@ -327,13 +328,13 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void CreateLargeNewBlobTwice_AtTheSameTime_TrueShouldReturnForTheFirstCompleted_And_FalseShouldReturnForTheSecondOne()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
 
             Assert.False(await blobClient.ExistsAsync());
@@ -357,10 +358,10 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             sourceStream_1.Position = 0;
             sourceStream_2.Position = 0;
 
-            var task_1 = blobProvider.CreateBlobAsync(blobName, sourceStream_1, CancellationToken.None);
-            var task_2 = blobProvider.CreateBlobAsync(blobName, sourceStream_2, CancellationToken.None);
+            Task<bool> task_1 = blobProvider.CreateBlobAsync(blobName, sourceStream_1, CancellationToken.None);
+            Task<bool> task_2 = blobProvider.CreateBlobAsync(blobName, sourceStream_2, CancellationToken.None);
 
-            var isCreateds = await Task.WhenAll(task_1, task_2);
+            bool[] isCreateds = await Task.WhenAll(task_1, task_2);
 
             Assert.True(await blobClient.ExistsAsync());
             Assert.True(isCreateds[0] ^ isCreateds[1]);
@@ -371,20 +372,20 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void DownloadBlob_StreamShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
 
             string blobContent = "example";
 
             // create a new blob
             using (MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(blobContent)))
             {
-                var isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
+                bool isCreated = await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None);
                 Assert.True(isCreated);
                 Assert.True(await blobClient.ExistsAsync());
             }
@@ -400,13 +401,13 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void DownloadNoExistingBlob_StreamShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             Assert.False(await blobClient.ExistsAsync());
 
             using Stream downloadStream = await blobProvider.GetBlobAsync(blobName, CancellationToken.None);
@@ -419,25 +420,25 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void UpdateStreamToBlob_TheBlobShouldBeOverwriten()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
             Assert.False(await blobClient.ExistsAsync());
 
             // create a new blob
             string blobContent = "example";
-            var blobUrl_1 = await blobProvider.UpdateBlobAsync(blobName, new MemoryStream(Encoding.ASCII.GetBytes(blobContent)), CancellationToken.None);
+            string blobUrl_1 = await blobProvider.UpdateBlobAsync(blobName, new MemoryStream(Encoding.ASCII.GetBytes(blobContent)), CancellationToken.None);
 
             Assert.True(await blobClient.ExistsAsync());
 
             using (var stream = new MemoryStream())
             {
-                var res = await blobClient.DownloadToAsync(stream);
+                Response res = await blobClient.DownloadToAsync(stream);
                 stream.Position = 0;
                 using var reader = new StreamReader(stream);
                 Assert.Equal(blobContent, await reader.ReadToEndAsync());
@@ -445,14 +446,14 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             // upload to a existing blob
             string newBlobContent = "new example";
-            var blobUrl_2 = await blobProvider.UpdateBlobAsync(blobName, new MemoryStream(Encoding.ASCII.GetBytes(newBlobContent)), CancellationToken.None);
+            string blobUrl_2 = await blobProvider.UpdateBlobAsync(blobName, new MemoryStream(Encoding.ASCII.GetBytes(newBlobContent)), CancellationToken.None);
 
             Assert.Equal(blobUrl_1, blobUrl_2);
             Assert.True(await blobClient.ExistsAsync());
 
             using (var stream = new MemoryStream())
             {
-                var res = await blobClient.DownloadToAsync(stream);
+                Response res = await blobClient.DownloadToAsync(stream);
                 stream.Position = 0;
                 using var reader = new StreamReader(stream);
                 Assert.Equal(newBlobContent, await reader.ReadToEndAsync());
@@ -464,28 +465,28 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void AcquireLease_WhenALeaseExists_ExceptionShouldBeThrown()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
             var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
-            var blobClient = blobContainerClient.GetBlobClient(blobName);
+            BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
             Assert.False(await blobClient.ExistsAsync());
 
             // create a new blob
             string blobContent = "example";
-            var blobUrl_1 = await blobProvider.CreateBlobAsync(blobName, new MemoryStream(Encoding.ASCII.GetBytes(blobContent)), CancellationToken.None);
+            bool blobUrl_1 = await blobProvider.CreateBlobAsync(blobName, new MemoryStream(Encoding.ASCII.GetBytes(blobContent)), CancellationToken.None);
             Assert.True(await blobClient.ExistsAsync());
 
-            var lease = await blobProvider.AcquireLeaseAsync(blobName, null, TimeSpan.FromSeconds(30));
+            string lease = await blobProvider.AcquireLeaseAsync(blobName, null, TimeSpan.FromSeconds(30));
             Assert.NotNull(lease);
 
-            var lease2 = await blobProvider.AcquireLeaseAsync(blobName, null, TimeSpan.FromSeconds(30));
+            string lease2 = await blobProvider.AcquireLeaseAsync(blobName, null, TimeSpan.FromSeconds(30));
             Assert.Null(lease2);
 
-            var lease3 = await blobProvider.AcquireLeaseAsync(blobName, lease, TimeSpan.FromSeconds(30));
+            string lease3 = await blobProvider.AcquireLeaseAsync(blobName, lease, TimeSpan.FromSeconds(30));
             Assert.Equal(lease, lease3);
 
             await blobContainerClient.DeleteAsync();
@@ -494,11 +495,11 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void AcquireLease_WhenBlobNotExists_NoLeaseShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
-            var lease = await blobProvider.AcquireLeaseAsync(blobName, null, TimeSpan.FromSeconds(30));
+            string lease = await blobProvider.AcquireLeaseAsync(blobName, null, TimeSpan.FromSeconds(30));
 
             Assert.Null(lease);
 
@@ -509,11 +510,11 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void ReleaseLease_WhenBlobNotExists_NoLeaseShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
-            var result = await blobProvider.ReleaseLeaseAsync(blobName, null);
+            bool result = await blobProvider.ReleaseLeaseAsync(blobName, null);
 
             Assert.False(result);
 
@@ -524,7 +525,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [Fact]
         public async void RenewLease_WhenBlobNotExists_NoLeaseShouldReturn()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
@@ -538,16 +539,16 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [SkippableFact]
         public async Task GivenANotExistingDirectoryName_WhenDeleteIfExists_NoExceptionShouldBeThrown()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
             AzureBlobContainerClient adlsClient = GetTestAdlsGen2Client(uniqueContainerName);
             Skip.If(adlsClient == null);
 
-            var blobContainerClient = GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient blobContainerClient = GetBlobContainerClient(uniqueContainerName);
             await blobContainerClient.CreateIfNotExistsAsync();
 
             try
             {
-                var exception = await Record.ExceptionAsync(async () => await adlsClient.DeleteDirectoryIfExistsAsync("foldernotexist"));
+                Exception exception = await Record.ExceptionAsync(async () => await adlsClient.DeleteDirectoryIfExistsAsync("foldernotexist"));
                 Assert.Null(exception);
             }
             finally
@@ -559,18 +560,18 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [SkippableFact]
         public async Task GivenAValidDirectoryName_WhenDeleteIfExists_DirectoryAndBlobsShouldBeDeleted()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
             AzureBlobContainerClient adlsClient = GetTestAdlsGen2Client(uniqueContainerName);
             Skip.If(adlsClient == null);
 
-            var blobContainerClient = GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient blobContainerClient = GetBlobContainerClient(uniqueContainerName);
             await blobContainerClient.CreateIfNotExistsAsync();
 
             try
             {
-                var blobName = "foo/bar1/1.txt";
+                string blobName = "foo/bar1/1.txt";
                 await blobContainerClient.UploadBlobAsync(blobName, new MemoryStream(new byte[] { 1, 2, 3 }));
-                var blobClient = blobContainerClient.GetBlobClient(blobName);
+                BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
                 Assert.True(await blobClient.ExistsAsync());
                 await adlsClient.DeleteDirectoryIfExistsAsync("foo/bar1");
                 Assert.False(await blobClient.ExistsAsync());
@@ -584,17 +585,17 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [SkippableFact]
         public async Task GivenANotExistingDirectoryName_WhenListPaths_NoPathShouldBeReturned()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
             AzureBlobContainerClient adlsClient = GetTestAdlsGen2Client(uniqueContainerName);
             Skip.If(adlsClient == null);
 
-            var blobContainerClient = GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient blobContainerClient = GetBlobContainerClient(uniqueContainerName);
             await blobContainerClient.CreateIfNotExistsAsync();
 
             try
             {
-                var paths = new List<PathItem>();
-                await foreach (var item in adlsClient.ListPathsAsync(uniqueContainerName))
+                List<PathItem> paths = new List<PathItem>();
+                await foreach (PathItem item in adlsClient.ListPathsAsync(uniqueContainerName))
                 {
                     paths.Add(item);
                 }
@@ -610,25 +611,25 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [SkippableFact]
         public async Task GivenAValidDirectoryName_WhenListPaths_AllPathsShouldBeReturned()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
             AzureBlobContainerClient adlsClient = GetTestAdlsGen2Client(uniqueContainerName);
             Skip.If(adlsClient == null);
 
-            var blobContainerClient = GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient blobContainerClient = GetBlobContainerClient(uniqueContainerName);
             await blobContainerClient.CreateIfNotExistsAsync();
 
             try
             {
                 // Set up directory info
-                var blobList = new List<string> { "foo/bar/1.txt", "foo/bar1/1.txt", "foo/bar2/2.txt", "foo/bar2/2.1.txt", "foo/bar3/3.txt" };
-                var expectedResult = new HashSet<string> { "foo/bar", "foo/bar1", "foo/bar2", "foo/bar3", "foo/bar/1.txt", "foo/bar1/1.txt", "foo/bar2/2.txt", "foo/bar2/2.1.txt", "foo/bar3/3.txt" };
-                foreach (var blob in blobList)
+                List<string> blobList = new List<string> { "foo/bar/1.txt", "foo/bar1/1.txt", "foo/bar2/2.txt", "foo/bar2/2.1.txt", "foo/bar3/3.txt" };
+                HashSet<string> expectedResult = new HashSet<string> { "foo/bar", "foo/bar1", "foo/bar2", "foo/bar3", "foo/bar/1.txt", "foo/bar1/1.txt", "foo/bar2/2.txt", "foo/bar2/2.1.txt", "foo/bar3/3.txt" };
+                foreach (string blob in blobList)
                 {
                     await blobContainerClient.UploadBlobAsync(blob, new MemoryStream(new byte[] { 1, 2, 3 }));
                 }
 
-                var paths = new List<PathItem>();
-                await foreach (var item in adlsClient.ListPathsAsync("foo"))
+                List<PathItem> paths = new List<PathItem>();
+                await foreach (PathItem item in adlsClient.ListPathsAsync("foo"))
                 {
                     paths.Add(item);
                 }
@@ -644,11 +645,11 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [SkippableFact]
         public async Task GivenANotExistingDirectoryName_WhenMoveDirectory_ExceptionShouldBeThrown()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
             AzureBlobContainerClient adlsClient = GetTestAdlsGen2Client(uniqueContainerName);
             Skip.If(adlsClient == null);
 
-            var blobContainerClient = GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient blobContainerClient = GetBlobContainerClient(uniqueContainerName);
             await blobContainerClient.CreateIfNotExistsAsync();
 
             try
@@ -664,27 +665,27 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         [SkippableFact]
         public async Task GivenADirectoryName_WhenMoveDirectories_AllSubDirectoriesShouldBeMoved()
         {
-            var uniqueContainerName = Guid.NewGuid().ToString("N");
+            string uniqueContainerName = Guid.NewGuid().ToString("N");
             AzureBlobContainerClient adlsClient = GetTestAdlsGen2Client(uniqueContainerName);
             Skip.If(adlsClient == null);
 
-            var blobContainerClient = GetBlobContainerClient(uniqueContainerName);
+            BlobContainerClient blobContainerClient = GetBlobContainerClient(uniqueContainerName);
             await blobContainerClient.CreateIfNotExistsAsync();
 
             try
             {
                 // Set up directory info
-                var blobList = new List<string> { "foo/bar/1.txt", "foo/bar1/1.txt", "foo/bar2/2.txt", "foo/bar2/2.1.txt", "foo/bar3/3.txt" };
-                var expectedBlobs = new List<string> { "boo/bar/1.txt", "boo/bar1/1.txt", "boo/bar2/2.txt", "boo/bar2/2.1.txt", "boo/bar3/3.txt" };
-                foreach (var blob in blobList)
+                List<string> blobList = new List<string> { "foo/bar/1.txt", "foo/bar1/1.txt", "foo/bar2/2.txt", "foo/bar2/2.1.txt", "foo/bar3/3.txt" };
+                List<string> expectedBlobs = new List<string> { "boo/bar/1.txt", "boo/bar1/1.txt", "boo/bar2/2.txt", "boo/bar2/2.1.txt", "boo/bar3/3.txt" };
+                foreach (string blob in blobList)
                 {
                     await blobContainerClient.UploadBlobAsync(blob, new MemoryStream(new byte[] { 1, 2, 3 }));
                 }
 
                 await adlsClient.MoveDirectoryAsync("foo", "boo");
-                foreach (var expectedBlob in expectedBlobs)
+                foreach (string expectedBlob in expectedBlobs)
                 {
-                    var blob = blobContainerClient.GetBlobClient(expectedBlob);
+                    BlobClient blob = blobContainerClient.GetBlobClient(expectedBlob);
                     Assert.True(await blob.ExistsAsync());
                 }
             }
@@ -703,7 +704,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
         // Some operations like GetSubDirectories and MoveDirectory is not supported in Azure Storage Emulator.
         private static AzureBlobContainerClient GetTestAdlsGen2Client(string containerName)
         {
-            var storageUrl = GetAdlsGen2StoreUrl();
+            string storageUrl = GetAdlsGen2StoreUrl();
             if (string.IsNullOrEmpty(storageUrl))
             {
                 return null;
@@ -714,7 +715,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
         private static BlobContainerClient GetBlobContainerClient(string containerName)
         {
-            var storageUrl = GetAdlsGen2StoreUrl();
+            string storageUrl = GetAdlsGen2StoreUrl();
             if (string.IsNullOrEmpty(storageUrl))
             {
                 return null;

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/Azure/AzureBlobContainerClientTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/Azure/AzureBlobContainerClientTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             // The container doesn't exist at the beginning
-            var blobServiceClient = new BlobServiceClient(ConnectionString);
+            BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
 
             BlobContainerClient container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
             Assert.False(container.Exists());
@@ -57,7 +57,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             // The container doesn't exist at the beginning
-            var blobServiceClient = new BlobServiceClient(ConnectionString);
+            BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
 
             BlobContainerClient container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
             Assert.False(container.Exists());
@@ -84,7 +84,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             string uniqueContainerName = Guid.NewGuid().ToString("N");
 
             // The container doesn't exist at the beginning
-            var blobServiceClient = new BlobServiceClient(ConnectionString);
+            BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
 
             BlobContainerClient container = blobServiceClient.GetBlobContainerClient(uniqueContainerName);
             Assert.False(container.Exists());
@@ -140,7 +140,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
                 Assert.True(await blobProvider.CreateBlobAsync(blobName, stream, CancellationToken.None));
             }
 
-            var blobServiceClient = new BlobServiceClient(ConnectionString);
+            BlobServiceClient blobServiceClient = new BlobServiceClient(ConnectionString);
 
             // delete the created container
             await blobServiceClient.DeleteBlobContainerAsync(uniqueContainerName);
@@ -169,7 +169,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             Assert.False(await blobClient.ExistsAsync());
 
@@ -205,7 +205,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             Assert.False(await blobClient.ExistsAsync());
 
@@ -226,7 +226,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
             Assert.False(await blobClient.ExistsAsync());
@@ -258,7 +258,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
             Assert.False(await blobClient.ExistsAsync());
@@ -296,7 +296,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
 
@@ -333,7 +333,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
 
@@ -377,7 +377,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
 
             string blobContent = "example";
@@ -392,7 +392,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             using Stream downloadStream = await blobProvider.GetBlobAsync(blobName, CancellationToken.None);
 
-            using var reader = new StreamReader(downloadStream);
+            using StreamReader reader = new StreamReader(downloadStream);
             Assert.Equal(blobContent, await reader.ReadToEndAsync());
 
             await blobContainerClient.DeleteAsync();
@@ -406,7 +406,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             Assert.False(await blobClient.ExistsAsync());
 
@@ -425,7 +425,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
             Assert.False(await blobClient.ExistsAsync());
@@ -436,11 +436,11 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             Assert.True(await blobClient.ExistsAsync());
 
-            using (var stream = new MemoryStream())
+            using (MemoryStream stream = new MemoryStream())
             {
                 Response res = await blobClient.DownloadToAsync(stream);
                 stream.Position = 0;
-                using var reader = new StreamReader(stream);
+                using StreamReader reader = new StreamReader(stream);
                 Assert.Equal(blobContent, await reader.ReadToEndAsync());
             }
 
@@ -451,11 +451,11 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             Assert.Equal(blobUrl_1, blobUrl_2);
             Assert.True(await blobClient.ExistsAsync());
 
-            using (var stream = new MemoryStream())
+            using (MemoryStream stream = new MemoryStream())
             {
                 Response res = await blobClient.DownloadToAsync(stream);
                 stream.Position = 0;
-                using var reader = new StreamReader(stream);
+                using StreamReader reader = new StreamReader(stream);
                 Assert.Equal(newBlobContent, await reader.ReadToEndAsync());
             }
 
@@ -470,7 +470,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
             AzureBlobContainerClient blobProvider = GetTestBlobProvider(ConnectionString, uniqueContainerName);
             string blobName = Guid.NewGuid().ToString("N");
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             BlobClient blobClient = blobContainerClient.GetBlobClient(blobName);
             await blobClient.DeleteIfExistsAsync();
             Assert.False(await blobClient.ExistsAsync());
@@ -503,7 +503,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             Assert.Null(lease);
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             await blobContainerClient.DeleteIfExistsAsync();
         }
 
@@ -518,7 +518,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             Assert.False(result);
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             await blobContainerClient.DeleteIfExistsAsync();
         }
 
@@ -532,7 +532,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests.Azure
 
             await Assert.ThrowsAsync<AzureBlobOperationFailedException>(() => blobProvider.RenewLeaseAsync(blobName, null));
 
-            var blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
+            BlobContainerClient blobContainerClient = new BlobContainerClient(ConnectionString, uniqueContainerName);
             await blobContainerClient.DeleteIfExistsAsync();
         }
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/DataWriterTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/DataWriterTests.cs
@@ -42,17 +42,17 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
         public async Task GivenAValidParameter_WhenWritingToBlob_CorrectContentShouldBeWritten()
         {
             var stream = new MemoryStream();
-            var bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
+            byte[] bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
             await stream.WriteAsync(bytes, 0, bytes.Length);
             stream.Position = 0;
             const long jobId = 1L;
-            var partIndex = 1;
-            var dataWriter = GetLocalDataWriter();
+            int partIndex = 1;
+            AzureBlobDataWriter dataWriter = GetLocalDataWriter();
             var streamData = new StreamBatchData(stream, 1, TestResourceType);
             await dataWriter.WriteAsync(streamData, jobId, partIndex, _testDate);
 
-            var containerClient = new AzureBlobContainerClientFactory(new DefaultTokenCredentialProvider(new NullLogger<DefaultTokenCredentialProvider>()), Options.Create(_storageConfiguration), _diagnosticLogger, new NullLoggerFactory()).Create(LocalTestStorageUrl, TestContainerName);
-            var blobStream = await containerClient.GetBlobAsync($"staging/{jobId:d20}/Patient/2021/10/01/Patient_{partIndex:d10}.parquet");
+            IAzureBlobContainerClient containerClient = new AzureBlobContainerClientFactory(new DefaultTokenCredentialProvider(new NullLogger<DefaultTokenCredentialProvider>()), Options.Create(_storageConfiguration), _diagnosticLogger, new NullLoggerFactory()).Create(LocalTestStorageUrl, TestContainerName);
+            Stream blobStream = await containerClient.GetBlobAsync($"staging/{jobId:d20}/Patient/2021/10/01/Patient_{partIndex:d10}.parquet");
             Assert.NotNull(blobStream);
 
             var resultStream = new MemoryStream();
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
         [Fact]
         public async Task GivenAnInvalidInputStreamData_WhenWritingToBlob_ExceptionShouldBeThrown()
         {
-            var dataWriter = GetLocalDataWriter();
+            AzureBlobDataWriter dataWriter = GetLocalDataWriter();
             var streamData = new StreamBatchData(null, 0, TestResourceType);
             await Assert.ThrowsAsync<ArgumentNullException>(() => dataWriter.WriteAsync(streamData, 0L, 0, _testDate));
         }
@@ -71,7 +71,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
         [Fact]
         public async void GivenAnInvalidBlobContainerClient_WhenCommitTheData_ExceptionShouldBeThrown()
         {
-            var invalidContainerDataWriter = GetBrokenDataWriter();
+            AzureBlobDataWriter invalidContainerDataWriter = GetBrokenDataWriter();
 
             await Assert.ThrowsAsync<AzureBlobOperationFailedException>(() => invalidContainerDataWriter.CommitJobDataAsync(00));
         }
@@ -82,9 +82,9 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
             var blobClient = new InMemoryBlobContainerClient();
 
             const long jobId = 1L;
-            var dataWriter = GetInMemoryDataWriter(blobClient);
+            AzureBlobDataWriter dataWriter = GetInMemoryDataWriter(blobClient);
 
-            var result = await dataWriter.TryCleanJobDataAsync(jobId, CancellationToken.None);
+            bool result = await dataWriter.TryCleanJobDataAsync(jobId, CancellationToken.None);
             Assert.True(result);
         }
 
@@ -94,19 +94,19 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
             var blobClient = new InMemoryBlobContainerClient();
 
             var stream = new MemoryStream();
-            var bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
+            byte[] bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
             await stream.WriteAsync(bytes, 0, bytes.Length);
             stream.Position = 0;
             const long jobId = 1L;
-            var partIndex = 1;
-            var dataWriter = GetInMemoryDataWriter(blobClient);
+            int partIndex = 1;
+            AzureBlobDataWriter dataWriter = GetInMemoryDataWriter(blobClient);
 
-            var blobName = $"staging/{jobId:d20}/Patient/2021/10/01/Patient_{partIndex:d10}.parquet";
+            string blobName = $"staging/{jobId:d20}/Patient/2021/10/01/Patient_{partIndex:d10}.parquet";
             await blobClient.CreateBlobAsync(blobName, stream, CancellationToken.None);
-            var blobExists = await blobClient.BlobExistsAsync(blobName, CancellationToken.None);
+            bool blobExists = await blobClient.BlobExistsAsync(blobName, CancellationToken.None);
             Assert.True(blobExists);
 
-            var result = await dataWriter.TryCleanJobDataAsync(jobId, CancellationToken.None);
+            bool result = await dataWriter.TryCleanJobDataAsync(jobId, CancellationToken.None);
             Assert.True(result);
             blobExists = await blobClient.BlobExistsAsync(blobName, CancellationToken.None);
             Assert.False(blobExists);
@@ -118,23 +118,23 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
             var blobClient = new InMemoryBlobContainerClient();
 
             var stream = new MemoryStream();
-            var bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
+            byte[] bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
             await stream.WriteAsync(bytes, 0, bytes.Length);
             stream.Position = 0;
             const long jobId = 1L;
-            var partIndex = 1;
-            var dataWriter = GetInMemoryDataWriter(blobClient);
+            int partIndex = 1;
+            AzureBlobDataWriter dataWriter = GetInMemoryDataWriter(blobClient);
 
-            var blobName = $"staging/{jobId:d20}/Patient/2021/10/01/Patient_{partIndex:d10}.parquet";
+            string blobName = $"staging/{jobId:d20}/Patient/2021/10/01/Patient_{partIndex:d10}.parquet";
             await blobClient.CreateBlobAsync(blobName, stream, CancellationToken.None);
-            var blobExists = await blobClient.BlobExistsAsync(blobName, CancellationToken.None);
+            bool blobExists = await blobClient.BlobExistsAsync(blobName, CancellationToken.None);
             Assert.True(blobExists);
 
-            var exception = await Record.ExceptionAsync(async () => await dataWriter.CommitJobDataAsync(jobId, CancellationToken.None));
+            Exception exception = await Record.ExceptionAsync(async () => await dataWriter.CommitJobDataAsync(jobId, CancellationToken.None));
             Assert.Null(exception);
             blobExists = await blobClient.BlobExistsAsync(blobName, CancellationToken.None);
             Assert.False(blobExists);
-            var expectedBlobName = $"result/Patient/2021/10/01/{jobId:d20}/Patient_{partIndex:d10}.parquet";
+            string expectedBlobName = $"result/Patient/2021/10/01/{jobId:d20}/Patient_{partIndex:d10}.parquet";
             blobExists = await blobClient.BlobExistsAsync(expectedBlobName, CancellationToken.None);
             Assert.True(blobExists);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/DataWriterTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests/DataWriterTests.cs
@@ -41,21 +41,21 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
         [Fact]
         public async Task GivenAValidParameter_WhenWritingToBlob_CorrectContentShouldBeWritten()
         {
-            var stream = new MemoryStream();
+            MemoryStream stream = new MemoryStream();
             byte[] bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
             await stream.WriteAsync(bytes, 0, bytes.Length);
             stream.Position = 0;
             const long jobId = 1L;
             int partIndex = 1;
             AzureBlobDataWriter dataWriter = GetLocalDataWriter();
-            var streamData = new StreamBatchData(stream, 1, TestResourceType);
+            StreamBatchData streamData = new StreamBatchData(stream, 1, TestResourceType);
             await dataWriter.WriteAsync(streamData, jobId, partIndex, _testDate);
 
             IAzureBlobContainerClient containerClient = new AzureBlobContainerClientFactory(new DefaultTokenCredentialProvider(new NullLogger<DefaultTokenCredentialProvider>()), Options.Create(_storageConfiguration), _diagnosticLogger, new NullLoggerFactory()).Create(LocalTestStorageUrl, TestContainerName);
             Stream blobStream = await containerClient.GetBlobAsync($"staging/{jobId:d20}/Patient/2021/10/01/Patient_{partIndex:d10}.parquet");
             Assert.NotNull(blobStream);
 
-            var resultStream = new MemoryStream();
+            MemoryStream resultStream = new MemoryStream();
             await blobStream.CopyToAsync(resultStream);
             Assert.Equal(bytes, resultStream.ToArray());
         }
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
         public async Task GivenAnInvalidInputStreamData_WhenWritingToBlob_ExceptionShouldBeThrown()
         {
             AzureBlobDataWriter dataWriter = GetLocalDataWriter();
-            var streamData = new StreamBatchData(null, 0, TestResourceType);
+            StreamBatchData streamData = new StreamBatchData(null, 0, TestResourceType);
             await Assert.ThrowsAsync<ArgumentNullException>(() => dataWriter.WriteAsync(streamData, 0L, 0, _testDate));
         }
 
@@ -79,7 +79,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
         [Fact]
         public async Task GivenEmptyFolder_WhenCleanJobData_ThenShouldNoExceptionBeThrown()
         {
-            var blobClient = new InMemoryBlobContainerClient();
+            InMemoryBlobContainerClient blobClient = new InMemoryBlobContainerClient();
 
             const long jobId = 1L;
             AzureBlobDataWriter dataWriter = GetInMemoryDataWriter(blobClient);
@@ -91,9 +91,9 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
         [Fact]
         public async Task GivenExistingJobData_WhenCleanJobData_ThenTheDataShouldBeDeleted()
         {
-            var blobClient = new InMemoryBlobContainerClient();
+            InMemoryBlobContainerClient blobClient = new InMemoryBlobContainerClient();
 
-            var stream = new MemoryStream();
+            MemoryStream stream = new MemoryStream();
             byte[] bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
             await stream.WriteAsync(bytes, 0, bytes.Length);
             stream.Position = 0;
@@ -115,9 +115,9 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
         [Fact]
         public async Task GivenValidData_WhenCommitData_ThenTheDataShouldBeCommitted()
         {
-            var blobClient = new InMemoryBlobContainerClient();
+            InMemoryBlobContainerClient blobClient = new InMemoryBlobContainerClient();
 
-            var stream = new MemoryStream();
+            MemoryStream stream = new MemoryStream();
             byte[] bytes = new byte[] { 1, 2, 3, 4, 5, 6 };
             await stream.WriteAsync(bytes, 0, bytes.Length);
             stream.Position = 0;
@@ -141,12 +141,12 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
 
         private static IDataSink GetBrokenDataSink()
         {
-            var jobConfig = new JobConfiguration
+            JobConfiguration jobConfig = new JobConfiguration
             {
                 ContainerName = TestContainerName,
             };
 
-            var storageConfig = new DataLakeStoreConfiguration
+            DataLakeStoreConfiguration storageConfig = new DataLakeStoreConfiguration
             {
                 StorageUrl = TestStorageUrl,
             };
@@ -158,12 +158,12 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
 
         private static IDataSink GetLocalDataSink()
         {
-            var jobConfig = new JobConfiguration
+            JobConfiguration jobConfig = new JobConfiguration
             {
                 ContainerName = TestContainerName,
             };
 
-            var storageConfig = new DataLakeStoreConfiguration
+            DataLakeStoreConfiguration storageConfig = new DataLakeStoreConfiguration
             {
                 StorageUrl = LocalTestStorageUrl,
             };
@@ -187,7 +187,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataWriter.UnitTests
 
         private static AzureBlobDataWriter GetInMemoryDataWriter(IAzureBlobContainerClient blobClient)
         {
-            var mockFactory = Substitute.For<IAzureBlobContainerClientFactory>();
+            IAzureBlobContainerClientFactory mockFactory = Substitute.For<IAzureBlobContainerClientFactory>();
             mockFactory.Create(Arg.Any<string>(), Arg.Any<string>()).ReturnsForAnyArgs(blobClient);
 
             return new AzureBlobDataWriter(

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             try
             {
                 // Run e2e
-                using var tokenSource = new CancellationTokenSource();
+                using CancellationTokenSource tokenSource = new CancellationTokenSource();
                 IHost host = CreateHostBuilder(configuration).Build();
                 Task hostRunTask = host.RunAsync(tokenSource.Token);
 
@@ -213,7 +213,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             try
             {
                 // Run e2e
-                using var tokenSource = new CancellationTokenSource();
+                using CancellationTokenSource tokenSource = new CancellationTokenSource();
                 IHost host = CreateHostBuilder(configuration).Build();
                 Task hostRunTask = host.RunAsync(tokenSource.Token);
 
@@ -295,7 +295,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             try
             {
                 // Run e2e
-                using var tokenSource = new CancellationTokenSource();
+                using CancellationTokenSource tokenSource = new CancellationTokenSource();
                 IHost host = CreateHostBuilder(configuration).Build();
                 Task hostRunTask = host.RunAsync(tokenSource.Token);
 
@@ -366,7 +366,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             try
             {
                 // trigger first time, only the resources imported before end time are synced.
-                using var tokenSource = new CancellationTokenSource();
+                using CancellationTokenSource tokenSource = new CancellationTokenSource();
                 IHost host = CreateHostBuilder(configuration).Build();
                 Task hostRunTask = host.RunAsync(tokenSource.Token);
 
@@ -394,7 +394,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 endTime = DateTimeOffset.Parse(
                     configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
 
-                using var tokenSource2 = new CancellationTokenSource();
+                using CancellationTokenSource tokenSource2 = new CancellationTokenSource();
                 IHost host2 = CreateHostBuilder(configuration).Build();
                 Task hostRunTask2 = host2.RunAsync(tokenSource2.Token);
 
@@ -452,7 +452,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
 
             // Make sure the container is deleted before running the tests
             Assert.False(await _blobContainerClient.ExistsAsync());
-            var azureTableClientFactory = new AzureTableClientFactory(
+            AzureTableClientFactory azureTableClientFactory = new AzureTableClientFactory(
                 new DefaultTokenCredentialProvider(new NullLogger<DefaultTokenCredentialProvider>()));
 
             _metadataStore = new AzureTableMetadataStore(azureTableClientFactory, jobConfig, new NullLogger<AzureTableMetadataStore>());
@@ -512,8 +512,8 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
 
             // check result
             string fileName = Path.Combine(ExpectedDataFolder, expectedResultFile);
-            var expectedResult = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(File.ReadAllText(fileName));
-            var result = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(jobInfo.Result);
+            FhirToDataLakeOrchestratorJobResult expectedResult = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(File.ReadAllText(fileName));
+            FhirToDataLakeOrchestratorJobResult result = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(jobInfo.Result);
 
             Assert.NotNull(expectedResult);
             Assert.NotNull(result);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/E2ETests.cs
@@ -9,8 +9,12 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Data.Tables;
 using Azure.Identity;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Queues;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -65,7 +69,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
         public E2ETests(ITestOutputHelper testOutputHelper)
         {
             _testOutputHelper = testOutputHelper;
-            var storageUri = Environment.GetEnvironmentVariable("dataLakeStore:storageUrl");
+            string storageUri = Environment.GetEnvironmentVariable("dataLakeStore:storageUrl");
             if (!string.IsNullOrWhiteSpace(storageUri))
             {
                 _testOutputHelper.WriteLine($"Using custom data lake storage uri {storageUri}");
@@ -77,7 +81,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
         public void GivenInvalidFilterScope_WhenBuildHost_ExceptionShouldBeThrown()
         {
             Environment.SetEnvironmentVariable("filter:filterScope", "Unsupported");
-            var configuration = new ConfigurationBuilder()
+            IConfigurationRoot configuration = new ConfigurationBuilder()
                 .AddJsonFile(TestConfigurationPath)
                 .AddEnvironmentVariables()
                 .Build();
@@ -93,7 +97,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             Environment.SetEnvironmentVariable("filter:filterScope", "Group");
             Environment.SetEnvironmentVariable("filter:groupId", groupId);
 
-            var configuration = new ConfigurationBuilder()
+            IConfigurationRoot configuration = new ConfigurationBuilder()
                 .AddJsonFile(TestConfigurationPath)
                 .AddEnvironmentVariables()
                 .Build();
@@ -111,11 +115,11 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             Environment.SetEnvironmentVariable("filter:filterScope", "System");
             Environment.SetEnvironmentVariable("filter:groupId", groupId);
 
-            var configuration = new ConfigurationBuilder()
+            IConfigurationRoot configuration = new ConfigurationBuilder()
                 .AddJsonFile(TestConfigurationPath)
                 .AddEnvironmentVariables()
                 .Build();
-            var exception = Record.Exception(() => CreateHostBuilder(configuration).Build());
+            Exception exception = Record.Exception(() => CreateHostBuilder(configuration).Build());
             Assert.Null(exception);
         }
 
@@ -130,19 +134,19 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             Environment.SetEnvironmentVariable("filter:requiredTypes", "Patient,Observation");
             Environment.SetEnvironmentVariable("filter:typeFilters", string.Empty);
 
-            var configuration = new ConfigurationBuilder()
+            IConfigurationRoot configuration = new ConfigurationBuilder()
                 .AddJsonFile(TestConfigurationPath)
                 .AddEnvironmentVariables()
                 .Build();
 
-            var endTime = DateTimeOffset.Parse(configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
+            DateTimeOffset endTime = DateTimeOffset.Parse(configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
 
             try
             {
                 // Run e2e
                 using var tokenSource = new CancellationTokenSource();
-                var host = CreateHostBuilder(configuration).Build();
-                var hostRunTask = host.RunAsync(tokenSource.Token);
+                IHost host = CreateHostBuilder(configuration).Build();
+                Task hostRunTask = host.RunAsync(tokenSource.Token);
 
                 CurrentTriggerEntity triggerEntity;
                 while (true)
@@ -171,10 +175,10 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 Assert.Equal(TriggerStatus.Completed, triggerEntity.TriggerStatus);
                 Assert.Equal(0, triggerEntity.TriggerSequenceId);
 
-                var orchestratorJobId = triggerEntity.OrchestratorJobId;
+                long orchestratorJobId = triggerEntity.OrchestratorJobId;
 
                 // Check job status
-                var jobInfo = await _queueClient.GetJobByIdAsync(QueueTypeByte, orchestratorJobId, true, CancellationToken.None);
+                JobInfo jobInfo = await _queueClient.GetJobByIdAsync(QueueTypeByte, orchestratorJobId, true, CancellationToken.None);
                 CheckJobStatus(jobInfo, "SystemScope_Patient_Observation.json");
 
                 // Check result files
@@ -199,19 +203,19 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             Environment.SetEnvironmentVariable("filter:requiredTypes", string.Empty);
             Environment.SetEnvironmentVariable("filter:typeFilters", string.Empty);
 
-            var configuration = new ConfigurationBuilder()
+            IConfigurationRoot configuration = new ConfigurationBuilder()
                 .AddJsonFile(TestConfigurationPath)
                 .AddEnvironmentVariables()
                 .Build();
 
-            var endTime = DateTimeOffset.Parse(configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
+            DateTimeOffset endTime = DateTimeOffset.Parse(configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
 
             try
             {
                 // Run e2e
                 using var tokenSource = new CancellationTokenSource();
-                var host = CreateHostBuilder(configuration).Build();
-                var hostRunTask = host.RunAsync(tokenSource.Token);
+                IHost host = CreateHostBuilder(configuration).Build();
+                Task hostRunTask = host.RunAsync(tokenSource.Token);
 
                 CurrentTriggerEntity triggerEntity;
                 while (true)
@@ -246,17 +250,17 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 Assert.Equal(TriggerStatus.Completed, triggerEntity.TriggerStatus);
                 Assert.Equal(0, triggerEntity.TriggerSequenceId);
 
-                var orchestratorJobId = triggerEntity.OrchestratorJobId;
+                long orchestratorJobId = triggerEntity.OrchestratorJobId;
 
                 // Check job status
-                var jobInfo =
+                JobInfo jobInfo =
                     await _queueClient.GetJobByIdAsync(QueueTypeByte, orchestratorJobId, true, CancellationToken.None);
                 CheckJobStatus(jobInfo, "GroupScope_OnePatient_All.json");
 
                 // Check result files
                 Assert.Equal(16, await GetResultFileCount(_blobContainerClient, "result"));
 
-                var patientVersions =
+                Dictionary<string, long> patientVersions =
                     await _metadataStore.GetPatientVersionsAsync(QueueTypeByte, CancellationToken.None);
 
                 Assert.Single(patientVersions);
@@ -281,19 +285,19 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             // this group includes all the 80 patients
             Environment.SetEnvironmentVariable("filter:groupId", "72d653ce-2dbb-4432-bfa0-9ac47d0e0a2c");
 
-            var configuration = new ConfigurationBuilder()
+            IConfigurationRoot configuration = new ConfigurationBuilder()
                 .AddJsonFile(TestConfigurationPath)
                 .AddEnvironmentVariables()
                 .Build();
 
-            var endTime = DateTimeOffset.Parse(configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
+            DateTimeOffset endTime = DateTimeOffset.Parse(configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
 
             try
             {
                 // Run e2e
                 using var tokenSource = new CancellationTokenSource();
-                var host = CreateHostBuilder(configuration).Build();
-                var hostRunTask = host.RunAsync(tokenSource.Token);
+                IHost host = CreateHostBuilder(configuration).Build();
+                Task hostRunTask = host.RunAsync(tokenSource.Token);
 
                 CurrentTriggerEntity triggerEntity = await WaitJobCompleted(endTime);
 
@@ -305,10 +309,10 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 Assert.Equal(TriggerStatus.Completed, triggerEntity.TriggerStatus);
                 Assert.Equal(0, triggerEntity.TriggerSequenceId);
 
-                var orchestratorJobId = triggerEntity.OrchestratorJobId;
+                long orchestratorJobId = triggerEntity.OrchestratorJobId;
 
                 // Check job status
-                var jobInfo = await _queueClient.GetJobByIdAsync(QueueTypeByte, orchestratorJobId, true, CancellationToken.None);
+                JobInfo jobInfo = await _queueClient.GetJobByIdAsync(QueueTypeByte, orchestratorJobId, true, CancellationToken.None);
                 CheckJobStatus(jobInfo, "GroupScope_AllPatient_Filters.json");
 
                 // Check result files
@@ -317,11 +321,11 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 Assert.Equal(1, await GetResultFileCount(_blobContainerClient, "result/MedicationRequest/2022/07/01"));
 
                 // Check patient version
-                var patientVersions =
+                Dictionary<string, long> patientVersions =
                     await _metadataStore.GetPatientVersionsAsync(QueueTypeByte, CancellationToken.None);
 
                 Assert.Equal(80, patientVersions.Count);
-                foreach (var kv in patientVersions)
+                foreach (KeyValuePair<string, long> kv in patientVersions)
                 {
                     Assert.Equal(1, kv.Value);
                 }
@@ -346,7 +350,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             // this group includes all the 80 patients
             Environment.SetEnvironmentVariable("filter:groupId", "72d653ce-2dbb-4432-bfa0-9ac47d0e0a2c");
 
-            var configuration = new ConfigurationBuilder()
+            IConfigurationRoot configuration = new ConfigurationBuilder()
                 .AddJsonFile(TestConfigurationPath)
                 .AddEnvironmentVariables()
                 .Build();
@@ -357,16 +361,16 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             // set schedulerCronExpression, so there are three triggers
             configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["schedulerCronExpression"] = "0 0 0 * * *";
 
-            var endTime = DateTimeOffset.Parse(configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
+            DateTimeOffset endTime = DateTimeOffset.Parse(configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
 
             try
             {
                 // trigger first time, only the resources imported before end time are synced.
                 using var tokenSource = new CancellationTokenSource();
-                var host = CreateHostBuilder(configuration).Build();
-                var hostRunTask = host.RunAsync(tokenSource.Token);
+                IHost host = CreateHostBuilder(configuration).Build();
+                Task hostRunTask = host.RunAsync(tokenSource.Token);
 
-                var triggerEntity = await WaitJobCompleted(endTime);
+                CurrentTriggerEntity triggerEntity = await WaitJobCompleted(endTime);
 
                 tokenSource.Cancel();
                 await hostRunTask;
@@ -376,10 +380,10 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 Assert.Equal(TriggerStatus.Completed, triggerEntity.TriggerStatus);
                 Assert.Equal(0, triggerEntity.TriggerSequenceId);
 
-                var orchestratorJobId = triggerEntity.OrchestratorJobId;
+                long orchestratorJobId = triggerEntity.OrchestratorJobId;
 
                 // Check job status
-                var jobInfo = await _queueClient.GetJobByIdAsync(QueueTypeByte, orchestratorJobId, true, CancellationToken.None);
+                JobInfo jobInfo = await _queueClient.GetJobByIdAsync(QueueTypeByte, orchestratorJobId, true, CancellationToken.None);
                 CheckJobStatus(jobInfo, "GroupScope_AllPatient_Filters_part1.json");
 
                 // modify the job end time to fake incremental sync.
@@ -391,8 +395,8 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                     configuration.GetSection(ConfigurationConstants.JobConfigurationKey)["endTime"]);
 
                 using var tokenSource2 = new CancellationTokenSource();
-                var host2 = CreateHostBuilder(configuration).Build();
-                var hostRunTask2 = host2.RunAsync(tokenSource2.Token);
+                IHost host2 = CreateHostBuilder(configuration).Build();
+                Task hostRunTask2 = host2.RunAsync(tokenSource2.Token);
 
                 triggerEntity = await WaitJobCompleted(endTime);
 
@@ -416,11 +420,11 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 Assert.Equal(2, await GetResultFileCount(_blobContainerClient, "result/MedicationRequest"));
 
                 // check patient version
-                var patientVersions =
+                Dictionary<string, long> patientVersions =
                     await _metadataStore.GetPatientVersionsAsync(QueueTypeByte, CancellationToken.None);
 
                 Assert.Equal(80, patientVersions.Count);
-                foreach (var kv in patientVersions)
+                foreach (KeyValuePair<string, long> kv in patientVersions)
                 {
                     Assert.Equal(1, kv.Value);
                 }
@@ -433,13 +437,13 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
 
         private async Task InitializeUniqueStorage()
         {
-            var uniqueName = Guid.NewGuid().ToString("N");
-            var jobInfoTableName = $"jobinfotable{uniqueName}";
-            var jobInfoQueueName = $"jobinfoqueue{uniqueName}";
-            var metadataTableName = $"metadatatable{uniqueName}";
+            string uniqueName = Guid.NewGuid().ToString("N");
+            string jobInfoTableName = $"jobinfotable{uniqueName}";
+            string jobInfoQueueName = $"jobinfoqueue{uniqueName}";
+            string metadataTableName = $"metadatatable{uniqueName}";
 
             _blobContainerClient = _blobServiceClient.GetBlobContainerClient(uniqueName);
-            var jobConfig = Options.Create(new JobConfiguration
+            IOptions<JobConfiguration> jobConfig = Options.Create(new JobConfiguration
             {
                 JobInfoTableName = jobInfoTableName,
                 MetadataTableName = metadataTableName,
@@ -476,7 +480,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 await Task.Delay(TimeSpan.FromSeconds(10), CancellationToken.None);
                 try
                 {
-                    var triggerEntity = await _metadataStore.GetCurrentTriggerEntityAsync(QueueTypeByte, CancellationToken.None);
+                    CurrentTriggerEntity triggerEntity = await _metadataStore.GetCurrentTriggerEntityAsync(QueueTypeByte, CancellationToken.None);
                     if (triggerEntity.TriggerStatus == TriggerStatus.Completed &&
                         triggerEntity.TriggerEndTime >= configurationEndTime)
                     {
@@ -494,8 +498,8 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
         {
             await _blobContainerClient.DeleteIfExistsAsync();
             await _metadataStore.DeleteMetadataTableAsync();
-            var jobInfoTableClient = _queueClientFactory.CreateTableClient();
-            var jobInfoQueueClient = _queueClientFactory.CreateQueueClient();
+            TableClient jobInfoTableClient = _queueClientFactory.CreateTableClient();
+            QueueClient jobInfoQueueClient = _queueClientFactory.CreateQueueClient();
             await jobInfoQueueClient.DeleteIfExistsAsync();
             await jobInfoTableClient.DeleteAsync();
         }
@@ -507,7 +511,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
             Assert.False(jobInfo.CancelRequested);
 
             // check result
-            var fileName = Path.Combine(ExpectedDataFolder, expectedResultFile);
+            string fileName = Path.Combine(ExpectedDataFolder, expectedResultFile);
             var expectedResult = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(File.ReadAllText(fileName));
             var result = JsonConvert.DeserializeObject<FhirToDataLakeOrchestratorJobResult>(jobInfo.Result);
 
@@ -524,10 +528,10 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
 
         private async Task<int> GetResultFileCount(BlobContainerClient blobContainerClient, string filePrefix)
         {
-            var resultFileCount = 0;
-            await foreach (var page in blobContainerClient.GetBlobsByHierarchyAsync(prefix: filePrefix).AsPages())
+            int resultFileCount = 0;
+            await foreach (Page<BlobHierarchyItem> page in blobContainerClient.GetBlobsByHierarchyAsync(prefix: filePrefix).AsPages())
             {
-                foreach (var blobItem in page.Values)
+                foreach (BlobHierarchyItem blobItem in page.Values)
                 {
                     _testOutputHelper.WriteLine($"Getting result file {blobItem.Blob.Name}.");
 
@@ -561,7 +565,7 @@ namespace Microsoft.Health.Fhir.Synapse.E2ETests
                 return false;
             }
 
-            foreach (var pair in actualDictionary)
+            foreach (KeyValuePair<string, int> pair in actualDictionary)
             {
                 if (expectedDictionary[pair.Key] != pair.Value)
                 {

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/Microsoft.Health.Fhir.Synapse.E2ETests.csproj
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/Microsoft.Health.Fhir.Synapse.E2ETests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="Microsoft.Health.Parquet" Version="$(ParquetNativeLibVersion)" />
+    <PackageReference Include="Microsoft.Health.Parquet" Version="1.0.0.215" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests/AzureStorageJobQueueClientTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests/AzureStorageJobQueueClientTests.cs
@@ -103,8 +103,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             const byte queueType = (byte)TestQueueType.GivenNewJobs_WhenEnqueueJobs_ThenCreatedJobsShouldBeReturned;
 
-            var definitions = new[] { "job1", "job2" };
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            string[]? definitions = new[] { "job1", "job2" };
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 definitions,
                 null,
@@ -123,7 +123,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             await CheckJob(jobInfos.First());
             await CheckJob(jobInfos.Last());
 
-            var jobInfo =
+            JobInfo? jobInfo =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(
                     queueType,
                     jobInfos.First().Id,
@@ -162,7 +162,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType =
                 (byte)TestQueueType.GivenJobsWithSameDefinition_WhenEnqueue_ThenOnlyOneJobShouldBeEnqueued;
 
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1" },
                 null,
@@ -170,7 +170,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None)).ToList();
             Assert.Single(jobInfos);
-            var jobId = jobInfos.First().Id;
+            long jobId = jobInfos.First().Id;
             jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1" },
@@ -190,7 +190,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 .GivenJobsWithSameDefinition_WhenEnqueueWithGroupId_ThenGroupIdShouldBeCorrect;
 
             long groupId = new Random().Next(int.MinValue, int.MaxValue);
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1", "job2" },
                 groupId,
@@ -234,11 +234,11 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var definitions = new List<string>();
-            var jobInfo1 =
+            List<string>? definitions = new List<string>();
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             definitions.Add(jobInfo1.Definition);
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             definitions.Add(jobInfo2.Definition);
             Assert.Null(
@@ -255,7 +255,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             const byte queueType = (byte)TestQueueType.GivenJobKeepPutHeartbeat_WhenDequeue_ThenJobShouldNotBeReturned;
 
-            var jobs = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobs = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { $"job1-{queueType}" },
                 null,
@@ -264,20 +264,20 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 CancellationToken.None)).ToList();
             Assert.Single(jobs);
 
-            var jobInfo1 =
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             Assert.Equal(jobInfo1.Id, jobs.First().Id);
             await Task.Delay(TimeSpan.FromSeconds(HeartbeatTimeoutSec));
 
             // without keep alive, the job should be dequeued again
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             Assert.NotNull(jobInfo2);
             Assert.Equal(jobInfo1.Id, jobInfo2.Id);
 
             await Task.Delay(TimeSpan.FromSeconds(HeartbeatTimeoutSec));
-            var cancelRequested = await _azureStorageJobQueueClient.KeepAliveJobAsync(jobInfo2, CancellationToken.None);
+            bool cancelRequested = await _azureStorageJobQueueClient.KeepAliveJobAsync(jobInfo2, CancellationToken.None);
             Assert.False(cancelRequested);
 
             // after keeping alive, the job should not be returned
@@ -301,13 +301,13 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var jobInfo1 =
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             jobInfo1.QueueType = queueType;
             jobInfo1.Result = "current-result";
             await _azureStorageJobQueueClient.KeepAliveJobAsync(jobInfo1, CancellationToken.None);
             await Task.Delay(TimeSpan.FromSeconds(HeartbeatTimeoutSec));
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             Assert.Equal(jobInfo1.Result, jobInfo2.Result);
         }
@@ -328,7 +328,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var jobInfo1 =
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             jobInfo1.QueueType = queueType;
             jobInfo1.Result = "current-result";
@@ -352,12 +352,12 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var jobInfo1 =
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             // the heartbeatTimeoutSec is used as the message visibility timeout
             await Task.Delay(TimeSpan.FromSeconds(HeartbeatTimeoutSec));
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             Assert.Equal(jobInfo1.Id, jobInfo2.Id);
@@ -381,16 +381,16 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var jobInfo1 =
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             Assert.Equal(JobStatus.Running, jobInfo1.Status);
             jobInfo1.Status = JobStatus.Failed;
             jobInfo1.Result = "Failed for cancellation";
             await _azureStorageJobQueueClient.CompleteJobAsync(jobInfo1, false, CancellationToken.None);
-            var jobInfo =
+            JobInfo? jobInfo =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(queueType, jobInfo1.Id, false, CancellationToken.None);
             Assert.Equal(JobStatus.Failed, jobInfo.Status);
             Assert.Equal(jobInfo1.Result, jobInfo.Result);
@@ -419,9 +419,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var jobInfo1 =
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             await _azureStorageJobQueueClient.CancelJobByGroupIdAsync(queueType, jobInfo1.GroupId, CancellationToken.None);
@@ -431,7 +431,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             jobInfo1.Status = JobStatus.Failed;
             jobInfo1.Result = "Failed for cancellation";
             await _azureStorageJobQueueClient.CompleteJobAsync(jobInfo1, false, CancellationToken.None);
-            var jobInfo =
+            JobInfo? jobInfo =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(queueType, jobInfo1.Id, false, CancellationToken.None);
             Assert.Equal(JobStatus.Failed, jobInfo.Status);
             Assert.Equal(jobInfo1.Result, jobInfo.Result);
@@ -452,7 +452,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType =
                 (byte)TestQueueType.GivenGroupJobs_WhenCancelJobsById_ThenOnlySingleJobShouldBeCancelled;
 
-            var jobs = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobs = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1", "job2", "job3" },
                 null,
@@ -461,9 +461,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 CancellationToken.None)).ToList();
 
             // get the job id of first message
-            var firstMessage = JobMessage.Parse((await _azureJobMessageQueueClient.PeekMessageAsync(CancellationToken.None)).Value.Body.ToString());
+            JobMessage? firstMessage = JobMessage.Parse((await _azureJobMessageQueueClient.PeekMessageAsync(CancellationToken.None)).Value.Body.ToString());
             Assert.NotNull(firstMessage);
-            var jobInfoEntity = (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(
+            TableEntity? jobInfoEntity = (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(
                 firstMessage?.PartitionKey,
                 firstMessage?.RowKey,
                 cancellationToken: CancellationToken.None)).Value;
@@ -478,10 +478,10 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None));
             Assert.EndsWith("the job status is Cancelled.", exception.Message);
 
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
-            var jobInfo3 =
+            JobInfo? jobInfo3 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             Assert.False(jobInfo2.CancelRequested);
@@ -506,7 +506,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var jobInfo1 =
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             jobInfo1.Status = JobStatus.Failed;
             jobInfo1.Result = "Failed for critical error";
@@ -525,8 +525,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType
                 .GivenJobsWithSameDefinition_WhenEnqueueConcurrently_ThenOnlyOneJobShouldBeEnqueued;
 
-            var tasks = new List<Task<IEnumerable<JobInfo>>>();
-            var task1 = _azureStorageJobQueueClient.EnqueueAsync(
+            List<Task<IEnumerable<JobInfo>>>? tasks = new List<Task<IEnumerable<JobInfo>>>();
+            Task<IEnumerable<JobInfo>>? task1 = _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1" },
                 null,
@@ -534,7 +534,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var task2 = _azureStorageJobQueueClient.EnqueueAsync(
+            Task<IEnumerable<JobInfo>>? task2 = _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1" },
                 null,
@@ -545,7 +545,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             tasks.Add(task1);
             tasks.Add(task2);
 
-            var result = await Task.WhenAll(tasks);
+            IEnumerable<JobInfo>[]? result = await Task.WhenAll(tasks);
             Assert.Single(result[0]);
             Assert.Single(result[1]);
             Assert.Equal(result[0].ToList().First().Id, result[1].ToList().First().Id);
@@ -575,8 +575,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             const byte queueType = (byte)TestQueueType.GivenCreatedJob_WhenEnqueueJobAgain_ThenTheExistingOneShouldBeReturned;
 
-            var definitions = new[] { "job1", "job2" };
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            string[]? definitions = new[] { "job1", "job2" };
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 definitions,
                 null,
@@ -587,7 +587,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             // check job info
             Assert.Equal(2, jobInfos.Count);
 
-            var jobInfo =
+            JobInfo? jobInfo =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(
                     queueType,
                     jobInfos.First().Id,
@@ -605,7 +605,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 CancellationToken.None)).ToList();
 
             Assert.Equal(2, jobInfos.Count);
-            var ids = new List<long> { jobInfos.First().Id, jobInfos.Last().Id };
+            List<long>? ids = new List<long> { jobInfos.First().Id, jobInfos.Last().Id };
             Assert.Contains(jobInfo.Id, ids);
         }
 
@@ -616,7 +616,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             const byte queueType = (byte)TestQueueType.GivenRunningJob_WhenEnqueueJobAgain_ThenTheExistingOneShouldBeReturned;
 
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1" },
                 null,
@@ -626,7 +626,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             Assert.Single(jobInfos);
 
-            var jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             Assert.Equal(JobStatus.Running, jobInfo1.Status);
 
@@ -642,7 +642,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             Assert.Equal(jobInfo1.Id, jobInfos.First().Id);
 
             // jobInfo1 should be the same as jobInfo2
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(queueType, jobInfo1.Id, false, CancellationToken.None);
 
             Assert.Equal(JobStatus.Running, jobInfo2.Status);
@@ -661,7 +661,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             const byte queueType = (byte)TestQueueType.GivenFinishedJob_WhenEnqueueJobAgain_ThenTheExistingOneShouldBeReturned;
 
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1", "job2", "job3" },
                 null,
@@ -671,9 +671,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             Assert.Equal(3, jobInfos.Count);
 
-            var jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
-            var jobInfo2 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
-            var jobInfo3 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo2 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo3 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             Assert.Equal(JobStatus.Running, jobInfo1.Status);
             Assert.Equal(JobStatus.Running, jobInfo2.Status);
@@ -693,7 +693,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             await _azureStorageJobQueueClient.CancelJobByIdAsync(queueType, jobInfo3.Id, CancellationToken.None);
 
             // Enqueue again, should return the existing one
-            var jobids = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<long>? jobids = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1", "job2", "job3" },
                 null,
@@ -706,13 +706,13 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             Assert.Contains(jobInfo2.Id, jobids);
             Assert.Contains(jobInfo3.Id, jobids);
 
-            var newJobInfo1 =
+            JobInfo? newJobInfo1 =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(queueType, jobInfo1.Id, false, CancellationToken.None);
             Assert.Equal(jobInfo1.Status, newJobInfo1.Status);
-            var newJobInfo2 =
+            JobInfo? newJobInfo2 =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(queueType, jobInfo2.Id, false, CancellationToken.None);
             Assert.Equal(jobInfo2.Status, newJobInfo2.Status);
-            var newJobInfo3 =
+            JobInfo? newJobInfo3 =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(queueType, jobInfo3.Id, false, CancellationToken.None);
             Assert.Equal(jobInfo3.Status, newJobInfo3.Status);
 
@@ -736,10 +736,10 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType.GivenEnqueueFailed_WhenEnqueueJobAgain_ThenContinueToEnqueue;
 
             // insert job info entity and job lock entity for job1
-            var (jobInfo, jobLockEntity) = await EnqueueStepBySteps(1001, queueType, 1);
+            (JobInfo? jobInfo, TableEntity? jobLockEntity) = await EnqueueStepBySteps(1001, queueType, 1);
 
             // enqueue job1 again
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1001", },
                 null,
@@ -754,7 +754,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             Assert.Null(jobLockEntity[JobLockEntityProperties.JobMessagePopReceipt]);
 
             await CheckJob(jobInfo, jobLockEntity);
-            var dequeuedJobInfo =
+            JobInfo? dequeuedJobInfo =
                 await _azureStorageJobQueueClient.DequeueAsync(jobInfo.QueueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             Assert.Equal(jobInfo.Id, dequeuedJobInfo.Id);
             await CleanStorage();
@@ -822,8 +822,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType.GivenJobsLargerThanTransactionLimitation_WhenEnqueue_ThenTheExceptionShouldBeThrown;
 
             const int jobCnt = 51;
-            var definitions = new List<string>();
-            for (var i = 0; i < jobCnt; i++)
+            List<string>? definitions = new List<string>();
+            for (int i = 0; i < jobCnt; i++)
             {
                 definitions.Add($"job{i}");
             }
@@ -856,7 +856,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             const byte queueType = (byte)TestQueueType.GivenJobsEnqueue_WhenDequeueConcurrently_ThenCorrectResultShouldBeReturned;
 
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1" },
                 null,
@@ -864,13 +864,13 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None)).ToList();
 
-            var tasks = new List<Task<JobInfo>>
+            List<Task<JobInfo>>? tasks = new List<Task<JobInfo>>
             {
                 _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None),
                 _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None),
             };
 
-            var result = await Task.WhenAll(tasks);
+            JobInfo[]? result = await Task.WhenAll(tasks);
             if (result[0] == null)
             {
                 Assert.Equal(jobInfos.First().Id, result[1].Id);
@@ -896,7 +896,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             };
 
             result = await Task.WhenAll(tasks);
-            var definitions = new List<string> { result[0].Definition, result[1].Definition };
+            List<string>? definitions = new List<string> { result[0].Definition, result[1].Definition };
 
             Assert.Contains("job2", definitions);
             Assert.Contains("job3", definitions);
@@ -909,7 +909,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType.GivenFinishedJobs_WhenDequeue_ThenNoResultShouldBeReturned;
 
             // enqueue jobs
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1", "job2", "job3" },
                 null,
@@ -918,7 +918,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 CancellationToken.None)).ToList();
             Assert.Equal(3, jobInfos.Count);
 
-            var jobInfo =
+            JobInfo? jobInfo =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             jobInfo.Status = JobStatus.Completed;
 
@@ -961,7 +961,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType.GivenJobCancelRequested_WhenDequeue_ThenTheJobShouldBeReturned;
 
             // enqueue jobs
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1" },
                 null,
@@ -970,7 +970,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 CancellationToken.None)).ToList();
             Assert.Single(jobInfos);
 
-            var jobInfo =
+            JobInfo? jobInfo =
                 await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             // cancel running job, only cancelRequest is set to true
@@ -997,7 +997,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             _ = await EnqueueStepBySteps(1, queueType, 3);
 
-            var jobInfo = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             Assert.Null(jobInfo);
         }
 
@@ -1008,7 +1008,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType.GivenJobsEnqueue_WhenGetJobWithReturnDefinitionFalse_ThenTheDefinitionShouldNotBeReturned;
 
             // enqueue jobs
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1" },
                 null,
@@ -1017,11 +1017,11 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 CancellationToken.None)).ToList();
             Assert.Single(jobInfos);
 
-            var jobInfo1 =
+            JobInfo? jobInfo1 =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(queueType, jobInfos.First().Id, true, CancellationToken.None);
             Assert.Equal("job1", jobInfo1.Definition);
 
-            var jobInfo2 =
+            JobInfo? jobInfo2 =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(queueType, jobInfos.First().Id, false, CancellationToken.None);
             Assert.Equal(jobInfos.First().Id, jobInfo2.Id);
             Assert.Null(jobInfo2.Definition);
@@ -1035,7 +1035,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType.GivenJobsEnqueue_WhenGetJobsByIds_ThenTheJobsShouldBeReturned;
 
             // enqueue jobs
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1", "job2", "job3" },
                 null,
@@ -1044,14 +1044,14 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 CancellationToken.None)).ToList();
             Assert.Equal(3, jobInfos.Count);
 
-            var retrievedJobInfos = (await _azureStorageJobQueueClient.GetJobsByIdsAsync(
+            List<JobInfo>? retrievedJobInfos = (await _azureStorageJobQueueClient.GetJobsByIdsAsync(
                 queueType,
                 new[] { jobInfos[0].Id, jobInfos[2].Id },
                 false,
                 CancellationToken.None)).ToList();
 
             Assert.Equal(2, retrievedJobInfos.Count);
-            var ids = new List<long> { retrievedJobInfos[0].Id, retrievedJobInfos[1].Id };
+            List<long>? ids = new List<long> { retrievedJobInfos[0].Id, retrievedJobInfos[1].Id };
             Assert.Contains(jobInfos[0].Id, ids);
             Assert.Contains(jobInfos[2].Id, ids);
         }
@@ -1079,12 +1079,12 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None);
 
-            var retrievedJobInfos =
+            List<JobInfo>? retrievedJobInfos =
                 (await _azureStorageJobQueueClient.GetJobByGroupIdAsync(queueType, 2, true, CancellationToken.None))
                 .ToList();
 
             Assert.Equal(2, retrievedJobInfos.Count);
-            var definitions = new List<string>
+            List<string>? definitions = new List<string>
                 { retrievedJobInfos.First().Definition, retrievedJobInfos.Last().Definition };
             Assert.Contains("job4", definitions);
             Assert.Contains("job5", definitions);
@@ -1098,7 +1098,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType.GivenJobsWithDifferentStatus_WhenCancelJobById_ThenTheStatusShouldBeSetCorrectly;
 
             // enqueue jobs
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1", "job2", "job3", "job4" },
                 1,
@@ -1106,9 +1106,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None)).ToList();
 
-            var jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
-            var jobInfo2 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
-            var jobInfo3 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo2 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo3 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             jobInfo2.Status = JobStatus.Failed;
             await _azureStorageJobQueueClient.CompleteJobAsync(jobInfo2, false, CancellationToken.None);
 
@@ -1120,7 +1120,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             await _azureStorageJobQueueClient.CancelJobByIdAsync(queueType, jobInfos[2].Id, CancellationToken.None);
             await _azureStorageJobQueueClient.CancelJobByIdAsync(queueType, jobInfos[3].Id, CancellationToken.None);
 
-            var retrievedJobInfos = (await _azureStorageJobQueueClient.GetJobsByIdsAsync(queueType, jobInfos.Select(j => j.Id).ToArray(), false, CancellationToken.None)).ToList();
+            List<JobInfo>? retrievedJobInfos = (await _azureStorageJobQueueClient.GetJobsByIdsAsync(queueType, jobInfos.Select(j => j.Id).ToArray(), false, CancellationToken.None)).ToList();
 
             Assert.Empty(retrievedJobInfos.Where(j => !j.CancelRequested));
 
@@ -1145,7 +1145,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             const byte queueType = (byte)TestQueueType.GivenJobsWithDifferentStatus_WhenCancelJobByGroupId_ThenTheStatusShouldBeSetCorrectly;
 
             // enqueue jobs
-            var jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
+            List<JobInfo>? jobInfos = (await _azureStorageJobQueueClient.EnqueueAsync(
                 queueType,
                 new[] { "job1", "job2", "job3", "job4" },
                 1,
@@ -1153,9 +1153,9 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None)).ToList();
 
-            var jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
-            var jobInfo2 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
-            var jobInfo3 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo2 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo3 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             jobInfo2.Status = JobStatus.Failed;
             await _azureStorageJobQueueClient.CompleteJobAsync(jobInfo2, false, CancellationToken.None);
 
@@ -1164,7 +1164,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             await _azureStorageJobQueueClient.CancelJobByGroupIdAsync(queueType, 1, CancellationToken.None);
 
-            var retrievedJobInfos = (await _azureStorageJobQueueClient.GetJobsByIdsAsync(queueType, jobInfos.Select(j => j.Id).ToArray(), false, CancellationToken.None)).ToList();
+            List<JobInfo>? retrievedJobInfos = (await _azureStorageJobQueueClient.GetJobsByIdsAsync(queueType, jobInfos.Select(j => j.Id).ToArray(), false, CancellationToken.None)).ToList();
 
             Assert.Empty(retrievedJobInfos.Where(j => !j.CancelRequested));
 
@@ -1197,11 +1197,11 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
                 false,
                 CancellationToken.None)).ToList();
 
-            var jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo1 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
 
             var jobInfoEntity = ((FhirToDataLakeAzureStorageJobInfo)jobInfo1).ToTableEntity();
 
-            var jobLockEntity = (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(
+            TableEntity? jobLockEntity = (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(
                 jobInfoEntity.PartitionKey,
                 AzureStorageKeyProvider.JobLockRowKey(((FhirToDataLakeAzureStorageJobInfo)jobInfo1).JobIdentifier()),
                 cancellationToken: CancellationToken.None)).Value;
@@ -1227,7 +1227,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             Assert.Equal("PopReceiptMismatch", exception.ErrorCode);
 
             // re-dequeue
-            var jobInfo2 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
+            JobInfo? jobInfo2 = await _azureStorageJobQueueClient.DequeueAsync(queueType, TestWorkerName, HeartbeatTimeoutSec, CancellationToken.None);
             Assert.NotNull(jobInfo2);
             Assert.Equal(jobInfo1.Id, jobInfo2.Id);
 
@@ -1235,7 +1235,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
             await Assert.ThrowsAsync<JobNotExistException>(async () => await _azureStorageJobQueueClient.KeepAliveJobAsync(jobInfo1, CancellationToken.None));
 
             // keep alive successfully for jobInfo2
-            var shouldCancel = await _azureStorageJobQueueClient.KeepAliveJobAsync(jobInfo2, CancellationToken.None);
+            bool shouldCancel = await _azureStorageJobQueueClient.KeepAliveJobAsync(jobInfo2, CancellationToken.None);
             Assert.False(shouldCancel);
 
             // complete jobInfo1 should throw JobNotExistException
@@ -1306,7 +1306,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
         private async Task CheckJob(JobInfo jobInfo, TableEntity? jobLockEntity = null)
         {
-            var retrievedJobInfo =
+            JobInfo? retrievedJobInfo =
                 await _azureStorageJobQueueClient.GetJobByIdAsync(
                     jobInfo.QueueType,
                     jobInfo.Id,
@@ -1317,19 +1317,19 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests
 
             // check table entity
             // job reverse index entity should exist
-            var reversePartitionKey = AzureStorageKeyProvider.JobReverseIndexPartitionKey(jobInfo.QueueType, retrievedJobInfo.Id);
-            var reverseRowKey = AzureStorageKeyProvider.JobReverseIndexRowKey(jobInfo.QueueType, retrievedJobInfo.Id);
-            var reverseIndexEntity = (await _azureJobInfoTableClient.GetEntityAsync<JobReverseIndexEntity>(reversePartitionKey, reverseRowKey)).Value;
+            string? reversePartitionKey = AzureStorageKeyProvider.JobReverseIndexPartitionKey(jobInfo.QueueType, retrievedJobInfo.Id);
+            string? reverseRowKey = AzureStorageKeyProvider.JobReverseIndexRowKey(jobInfo.QueueType, retrievedJobInfo.Id);
+            JobReverseIndexEntity? reverseIndexEntity = (await _azureJobInfoTableClient.GetEntityAsync<JobReverseIndexEntity>(reversePartitionKey, reverseRowKey)).Value;
             Assert.NotNull(reverseIndexEntity);
 
             // job info entity should exist
-            var retrievedJobInfoEntity = (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(reverseIndexEntity.JobInfoEntityPartitionKey, reverseIndexEntity.JobInfoEntityRowKey)).Value;
+            TableEntity? retrievedJobInfoEntity = (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(reverseIndexEntity.JobInfoEntityPartitionKey, reverseIndexEntity.JobInfoEntityRowKey)).Value;
             Assert.NotNull(retrievedJobInfoEntity);
 
             // job lock entity should exist
-            var jobLockEntityRowKey =
+            string? jobLockEntityRowKey =
                 AzureStorageKeyProvider.JobLockRowKey(((FhirToDataLakeAzureStorageJobInfo)retrievedJobInfo).JobIdentifier());
-            var retrievedJobLockEntity =
+            TableEntity? retrievedJobLockEntity =
                 (await _azureJobInfoTableClient.GetEntityAsync<TableEntity>(
                     retrievedJobInfoEntity.PartitionKey,
                     jobLockEntityRowKey)).Value;

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests/Extensions/JobInfoExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests/Extensions/JobInfoExtensionsTests.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests.Extensions
         [Fact]
         public void GivenDefaultJobInfo_WhenToTableEntity_ThenTheCorrectTableEntityShouldBeReturned()
         {
-            var jobInfo = new FhirToDataLakeAzureStorageJobInfo();
-            var tableEntity = jobInfo.ToTableEntity();
+            FhirToDataLakeAzureStorageJobInfo jobInfo = new FhirToDataLakeAzureStorageJobInfo();
+            TableEntity tableEntity = jobInfo.ToTableEntity();
             Assert.NotNull(tableEntity);
             Assert.Null(jobInfo.Status);
             Assert.Equal((int)JobStatus.Created, (int)tableEntity[JobInfoEntityProperties.Status]);
@@ -37,8 +37,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests.Extensions
         [Fact]
         public void GivenAzureStorageJobInfo_WhenToTableEntity_ThenTheCorrectTableEntityShouldBeReturned()
         {
-            var jobInfo = new AzureStorageJobInfo();
-            var tableEntity = jobInfo.ToTableEntity();
+            AzureStorageJobInfo jobInfo = new AzureStorageJobInfo();
+            TableEntity tableEntity = jobInfo.ToTableEntity();
             Assert.NotNull(tableEntity);
             Assert.Null(jobInfo.Status);
             Assert.Equal((int)JobStatus.Created, (int)tableEntity[JobInfoEntityProperties.Status]);
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests.Extensions
         [Fact]
         public void GivenValidJobInfo_WhenToTableEntity_ThenTheCorrectTableEntityShouldBeReturned()
         {
-            var jobInfo = new FhirToDataLakeAzureStorageJobInfo
+            FhirToDataLakeAzureStorageJobInfo jobInfo = new FhirToDataLakeAzureStorageJobInfo
             {
                 Id = 1,
                 QueueType = (byte)QueueType.FhirToDataLake,
@@ -61,7 +61,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests.Extensions
                 CreateDate = DateTime.UtcNow,
                 HeartbeatDateTime = DateTime.UtcNow,
             };
-            var tableEntity = jobInfo.ToTableEntity();
+            TableEntity tableEntity = jobInfo.ToTableEntity();
             Assert.NotNull(tableEntity);
             Assert.Equal(jobInfo.Id, (long)tableEntity[JobInfoEntityProperties.Id]);
             Assert.Equal(jobInfo.QueueType, (int)tableEntity[JobInfoEntityProperties.QueueType]);
@@ -90,7 +90,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests.Extensions
         [Fact]
         public void GivenValidTableEntity_WhenToJobInfo_ThenTheCorrectResultShouldBeReturned()
         {
-            var jobInfoEntity = new TableEntity("partitionKey", "rowKey")
+            TableEntity jobInfoEntity = new TableEntity("partitionKey", "rowKey")
             {
                 { JobInfoEntityProperties.Id, 1L },
                 { JobInfoEntityProperties.QueueType, (int)QueueType.FhirToDataLake },
@@ -105,7 +105,7 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests.Extensions
                 { JobInfoEntityProperties.HeartbeatDateTime, DateTimeOffset.Now },
                 { JobInfoEntityProperties.HeartbeatTimeoutSec, 0L },
             };
-            var jobInfo = jobInfoEntity.ToJobInfo<FhirToDataLakeAzureStorageJobInfo>();
+            FhirToDataLakeAzureStorageJobInfo jobInfo = jobInfoEntity.ToJobInfo<FhirToDataLakeAzureStorageJobInfo>();
             Assert.NotNull(jobInfo);
             Assert.Equal((long)jobInfoEntity[JobInfoEntityProperties.Id], jobInfo.Id);
             Assert.Equal((int)jobInfoEntity[JobInfoEntityProperties.QueueType], jobInfo.QueueType);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests/Extensions/StringExtensionsTests.cs
@@ -32,26 +32,26 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests.Extensions
         [MemberData(nameof(NullOrEmptyInput))]
         public void GivenNullOrEmptyString_WhenComputeHash_ThenTheInputShouldBeReturn(string inputStr, string expectedHash)
         {
-            var hash = inputStr.ComputeHash();
+            string? hash = inputStr.ComputeHash();
             Assert.Equal(expectedHash, hash);
         }
 
         [Fact]
         public void GivenValidString_WhenComputeHash_ThenTheHashStringShouldBeReturn()
         {
-            var inputStr = "input string";
-            var hash = inputStr.ComputeHash();
+            string? inputStr = "input string";
+            string? hash = inputStr.ComputeHash();
             Assert.NotEmpty(hash);
         }
 
         [Fact]
         public void GivenTwoSameStrings_WhenComputeHash_ThenTheHashStringsShouldBeTheSame()
         {
-            var inputStr1 = "same input string";
-            var hash1 = inputStr1.ComputeHash();
+            string? inputStr1 = "same input string";
+            string? hash1 = inputStr1.ComputeHash();
 
-            var inputStr2 = "same input string";
-            var hash2 = inputStr2.ComputeHash();
+            string? inputStr2 = "same input string";
+            string? hash2 = inputStr2.ComputeHash();
             Assert.Equal(hash1, hash2);
         }
 
@@ -59,8 +59,8 @@ namespace Microsoft.Health.Fhir.Synapse.JobManagement.UnitTests.Extensions
         [MemberData(nameof(DifferentInputs))]
         public void GivenDifferentStrings_WhenComputeHash_ThenTheHashStringsShouldBeDifferent(string inputStr1, string inputStr2)
         {
-            var hash1 = inputStr1.ComputeHash();
-            var hash2 = inputStr2.ComputeHash();
+            string? hash1 = inputStr1.ComputeHash();
+            string? hash2 = inputStr2.ComputeHash();
             Assert.NotEqual(hash1, hash2);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/AzureBlobStorageHealthCheckerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/AzureBlobStorageHealthCheckerTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
                 _diagnosticLogger,
                 new NullLogger<AzureBlobStorageHealthChecker>());
 
-            var result = await storageAccountHealthChecker.PerformHealthCheckAsync();
+            HealthCheckResult result = await storageAccountHealthChecker.PerformHealthCheckAsync();
             Assert.Equal(HealthCheckStatus.HEALTHY, result.Status);
             Assert.False(result.IsCritical);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
                 _diagnosticLogger,
                 new NullLogger<AzureBlobStorageHealthChecker>());
 
-            var result = await storageAccountHealthChecker.PerformHealthCheckAsync();
+            HealthCheckResult result = await storageAccountHealthChecker.PerformHealthCheckAsync();
             Assert.Equal(HealthCheckStatus.UNHEALTHY, result.Status);
             Assert.False(result.IsCritical);
         }
@@ -101,7 +101,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
                 _diagnosticLogger,
                 new NullLogger<AzureBlobStorageHealthChecker>());
 
-            var result = await storageAccountHealthChecker.PerformHealthCheckAsync();
+            HealthCheckResult result = await storageAccountHealthChecker.PerformHealthCheckAsync();
             Assert.Equal(HealthCheckStatus.UNHEALTHY, result.Status);
             Assert.False(result.IsCritical);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/FhirServerHealthCheckerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/FhirServerHealthCheckerTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
                 _diagnosticLogger,
                 new NullLogger<FhirServerHealthChecker>());
 
-            var result = await fhirServerHealthChecker.PerformHealthCheckAsync();
+            HealthCheckResult result = await fhirServerHealthChecker.PerformHealthCheckAsync();
             Assert.Equal(HealthCheckStatus.HEALTHY, result.Status);
         }
 
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
                 _diagnosticLogger,
                 new NullLogger<FhirServerHealthChecker>());
 
-            var result = await fhirServerHealthChecker.PerformHealthCheckAsync();
+            HealthCheckResult result = await fhirServerHealthChecker.PerformHealthCheckAsync();
             Assert.Equal(HealthCheckStatus.UNHEALTHY, result.Status);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/FhirServerHealthCheckerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/FhirServerHealthCheckerTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
         [Fact]
         public async Task When_FhirDataClient_CanSearch_HealthCheck_Succeeds()
         {
-            var fhirDataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient fhirDataClient = Substitute.For<IFhirDataClient>();
             fhirDataClient.SearchAsync(default).Returns(Task.FromResult("result"));
-            var fhirServerHealthChecker = new FhirServerHealthChecker(
+            FhirServerHealthChecker fhirServerHealthChecker = new FhirServerHealthChecker(
                 fhirDataClient,
                 _diagnosticLogger,
                 new NullLogger<FhirServerHealthChecker>());
@@ -37,9 +37,9 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
         [Fact]
         public async Task When_BlobClient_ThrowExceptionWhenReadWriteABlob_HealthCheck_Fails()
         {
-            var fhirDataClient = Substitute.For<IFhirDataClient>();
+            IFhirDataClient fhirDataClient = Substitute.For<IFhirDataClient>();
             fhirDataClient.SearchAsync(default).ThrowsAsyncForAnyArgs(new Exception());
-            var fhirServerHealthChecker = new FhirServerHealthChecker(
+            FhirServerHealthChecker fhirServerHealthChecker = new FhirServerHealthChecker(
                 fhirDataClient,
                 _diagnosticLogger,
                 new NullLogger<FhirServerHealthChecker>());

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/SchedulerServiceHealthCheckerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/SchedulerServiceHealthCheckerTests.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
         [Fact]
         public async Task When_SchedulerService_IsActive_HealthCheck_Succeeds()
         {
-            var schedulerService = Substitute.For<ISchedulerService>();
+            ISchedulerService schedulerService = Substitute.For<ISchedulerService>();
             schedulerService.LastHeartbeat.Returns(DateTimeOffset.UtcNow);
-            var schedulerServiceHealthChecker = new SchedulerServiceHealthChecker(
+            SchedulerServiceHealthChecker schedulerServiceHealthChecker = new SchedulerServiceHealthChecker(
                 schedulerService,
                 _diagnosticLogger,
                 new NullLogger<SchedulerServiceHealthChecker>());
@@ -37,9 +37,9 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
         [Fact]
         public async Task When_SchedulerService_IsInactive_HealthCheck_Fails()
         {
-            var schedulerService = Substitute.For<ISchedulerService>();
+            ISchedulerService schedulerService = Substitute.For<ISchedulerService>();
             schedulerService.LastHeartbeat.Returns(DateTimeOffset.UtcNow.AddMinutes(-5));
-            var schedulerServiceHealthChecker = new SchedulerServiceHealthChecker(
+            SchedulerServiceHealthChecker schedulerServiceHealthChecker = new SchedulerServiceHealthChecker(
                 schedulerService,
                 _diagnosticLogger,
                 new NullLogger<SchedulerServiceHealthChecker>());

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/SchedulerServiceHealthCheckerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/Checkers/SchedulerServiceHealthCheckerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
                 _diagnosticLogger,
                 new NullLogger<SchedulerServiceHealthChecker>());
 
-            var result = await schedulerServiceHealthChecker.PerformHealthCheckAsync();
+            HealthCheckResult result = await schedulerServiceHealthChecker.PerformHealthCheckAsync();
             Assert.Equal(HealthCheckStatus.HEALTHY, result.Status);
             Assert.True(result.IsCritical);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests.Checkers
                 _diagnosticLogger,
                 new NullLogger<SchedulerServiceHealthChecker>());
 
-            var result = await schedulerServiceHealthChecker.PerformHealthCheckAsync();
+            HealthCheckResult result = await schedulerServiceHealthChecker.PerformHealthCheckAsync();
             Assert.Equal(HealthCheckStatus.UNHEALTHY, result.Status);
             Assert.True(result.IsCritical);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/HealthCheckEngineTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/HealthCheckEngineTests.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests
         public async Task When_All_HealthCheck_Complete_All_AreMaked_WithCorrectStatus()
         {
             List<IHealthChecker> healthCheckers = new List<IHealthChecker>() { _fhirServerHealthChecker, _azureBlobStorageHealthChecker };
-            var healthCheckConfiduration = new HealthCheckConfiguration();
-            var healthCheckEngine = new HealthCheckEngine(healthCheckers, Options.Create(healthCheckConfiduration));
+            HealthCheckConfiguration healthCheckConfiduration = new HealthCheckConfiguration();
+            HealthCheckEngine healthCheckEngine = new HealthCheckEngine(healthCheckers, Options.Create(healthCheckConfiduration));
 
             OverallHealthStatus healthStatus = await healthCheckEngine.CheckHealthAsync();
             IOrderedEnumerable<HealthCheckResult> sortedHealthCheckResults = healthStatus.HealthCheckResults.OrderBy(h => h.Name);
@@ -73,12 +73,12 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests
         [Fact]
         public async Task When_HealthCheck_ExceedsHealthCheckTimeLimit_HealthCheck_MarkedAsFailed()
         {
-            var healthCheckConfiguration = new HealthCheckConfiguration();
+            HealthCheckConfiguration healthCheckConfiguration = new HealthCheckConfiguration();
             healthCheckConfiguration.HealthCheckTimeoutInSeconds = 1;
 
-            var mockTimeOutHealthChecker = new MockTimeoutHealthChecker(new DiagnosticLogger() ,new NullLogger<MockTimeoutHealthChecker>());
+            MockTimeoutHealthChecker mockTimeOutHealthChecker = new MockTimeoutHealthChecker(new DiagnosticLogger() ,new NullLogger<MockTimeoutHealthChecker>());
             List<IHealthChecker> healthCheckers = new List<IHealthChecker>() { _fhirServerHealthChecker, _azureBlobStorageHealthChecker, mockTimeOutHealthChecker };
-            var healthCheckEngine = new HealthCheckEngine(healthCheckers, Options.Create(healthCheckConfiguration));
+            HealthCheckEngine healthCheckEngine = new HealthCheckEngine(healthCheckers, Options.Create(healthCheckConfiguration));
 
             OverallHealthStatus healthStatus = await healthCheckEngine.CheckHealthAsync();
             IOrderedEnumerable<HealthCheckResult> sortedHealthCheckResults = healthStatus.HealthCheckResults.OrderBy(h => h.Name);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/HealthCheckEngineTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/HealthCheckEngineTests.cs
@@ -48,13 +48,13 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests
         [Fact]
         public async Task When_All_HealthCheck_Complete_All_AreMaked_WithCorrectStatus()
         {
-            var healthCheckers = new List<IHealthChecker>() { _fhirServerHealthChecker, _azureBlobStorageHealthChecker };
+            List<IHealthChecker> healthCheckers = new List<IHealthChecker>() { _fhirServerHealthChecker, _azureBlobStorageHealthChecker };
             var healthCheckConfiduration = new HealthCheckConfiguration();
             var healthCheckEngine = new HealthCheckEngine(healthCheckers, Options.Create(healthCheckConfiduration));
 
-            var healthStatus = await healthCheckEngine.CheckHealthAsync();
-            var sortedHealthCheckResults = healthStatus.HealthCheckResults.OrderBy(h => h.Name);
-            var expectedResult = JsonSerializer.Deserialize<List<HealthCheckResult>>(File.ReadAllText("TestData/result.txt"));
+            OverallHealthStatus healthStatus = await healthCheckEngine.CheckHealthAsync();
+            IOrderedEnumerable<HealthCheckResult> sortedHealthCheckResults = healthStatus.HealthCheckResults.OrderBy(h => h.Name);
+            List<HealthCheckResult> expectedResult = JsonSerializer.Deserialize<List<HealthCheckResult>>(File.ReadAllText("TestData/result.txt"));
             Assert.Collection(
                 sortedHealthCheckResults,
                 p =>
@@ -77,11 +77,11 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests
             healthCheckConfiguration.HealthCheckTimeoutInSeconds = 1;
 
             var mockTimeOutHealthChecker = new MockTimeoutHealthChecker(new DiagnosticLogger() ,new NullLogger<MockTimeoutHealthChecker>());
-            var healthCheckers = new List<IHealthChecker>() { _fhirServerHealthChecker, _azureBlobStorageHealthChecker, mockTimeOutHealthChecker };
+            List<IHealthChecker> healthCheckers = new List<IHealthChecker>() { _fhirServerHealthChecker, _azureBlobStorageHealthChecker, mockTimeOutHealthChecker };
             var healthCheckEngine = new HealthCheckEngine(healthCheckers, Options.Create(healthCheckConfiguration));
 
-            var healthStatus = await healthCheckEngine.CheckHealthAsync();
-            var sortedHealthCheckResults = healthStatus.HealthCheckResults.OrderBy(h => h.Name);
+            OverallHealthStatus healthStatus = await healthCheckEngine.CheckHealthAsync();
+            IOrderedEnumerable<HealthCheckResult> sortedHealthCheckResults = healthStatus.HealthCheckResults.OrderBy(h => h.Name);
             Assert.Collection(
                 sortedHealthCheckResults,
                 p =>

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/MockTimeoutHealthChecker.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Parquet.HealthCheck.UnitTests/MockTimeoutHealthChecker.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Health.Fhir.Synapse.HealthCheck.UnitTests
 
         protected override async Task<HealthCheckResult> PerformHealthCheckImplAsync(CancellationToken cancellationToken)
         {
-            var result = new HealthCheckResult("MockTimeout", true);
+            HealthCheckResult result = new HealthCheckResult("MockTimeout", true);
             try
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(1500), cancellationToken);

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryAccessTokenProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryAccessTokenProviderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
         [Fact]
         public async Task GivenARegistry_WithoutRbacGranted_WhenGetToken_ExceptionShouldBeThrown()
         {
-            var acrTokenProvider = GetMockAcrTokenProvider(HttpStatusCode.Unauthorized);
+            ContainerRegistryAccessTokenProvider acrTokenProvider = GetMockAcrTokenProvider(HttpStatusCode.Unauthorized);
 
             await Assert.ThrowsAsync<ContainerRegistryTokenException>(() => acrTokenProvider.GetTokenAsync(RegistryServer, default));
         }
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
         [Fact]
         public async Task GivenANotFoundRegistry_WhenGetToken_ExceptionShouldBeThrown()
         {
-            var acrTokenProvider = GetMockAcrTokenProvider(HttpStatusCode.NotFound);
+            ContainerRegistryAccessTokenProvider acrTokenProvider = GetMockAcrTokenProvider(HttpStatusCode.NotFound);
             await Assert.ThrowsAsync<ContainerRegistryTokenException>(() => acrTokenProvider.GetTokenAsync(RegistryServer, default));
         }
 
@@ -47,14 +47,14 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
         [InlineData("{\"refresh_token\":\"refresh_token_test\", \"access_token\":\"\"}")]
         public async Task GivenAValidRegistry_WhenRefreshTokenIsEmpty_ExceptionShouldBeThrown(string content)
         {
-            var acrTokenProvider = GetMockAcrTokenProvider(HttpStatusCode.OK, content);
+            ContainerRegistryAccessTokenProvider acrTokenProvider = GetMockAcrTokenProvider(HttpStatusCode.OK, content);
             await Assert.ThrowsAsync<ContainerRegistryTokenException>(() => acrTokenProvider.GetTokenAsync(RegistryServer, default));
         }
 
         [Fact]
         public async Task GivenAValidRegistry_WhenGetToken_CorrectResultShouldBeReturned()
         {
-            var acrTokenProvider = GetMockAcrTokenProvider(HttpStatusCode.OK, "{\"refresh_token\":\"refresh_token_test\", \"access_token\":\"access_token_test\"}");
+            ContainerRegistryAccessTokenProvider acrTokenProvider = GetMockAcrTokenProvider(HttpStatusCode.OK, "{\"refresh_token\":\"refresh_token_test\", \"access_token\":\"access_token_test\"}");
             string accessToken = await acrTokenProvider.GetTokenAsync(RegistryServer, default);
             Assert.Equal("Bearer access_token_test", accessToken);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryAccessTokenProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryAccessTokenProviderTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
             ITokenCredentialProvider tokenProvider = Substitute.For<ITokenCredentialProvider>();
 
             // tokenProvider.GetAccessTokenAsync(default, default).ReturnsForAnyArgs("Bearer test");
-            var httpClient = new HttpClient(new MockHttpMessageHandler(content, statusCode));
+            HttpClient httpClient = new HttpClient(new MockHttpMessageHandler(content, statusCode));
             return new ContainerRegistryAccessTokenProvider(tokenProvider, httpClient, new DiagnosticLogger(), new NullLogger<ContainerRegistryAccessTokenProvider>());
         }
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryTemplateProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryTemplateProviderTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
             ImageInfo imageInfo = ImageInfo.CreateFromImageReference(_testImageReference);
             await ContainerRegistryTestUtils.GenerateImageAsync(imageInfo, _testContainerRegistryAccessToken, TestUtils.TestTemplateTarGzPath);
 
-            var containerRegistryTemplateProvider = new ContainerRegistryTemplateProvider(
+            ContainerRegistryTemplateProvider containerRegistryTemplateProvider = new ContainerRegistryTemplateProvider(
                 _testTokenProvider,
                 new DiagnosticLogger(),
                 new NullLogger<ContainerRegistryTemplateProvider>());
@@ -63,7 +63,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
         {
             Skip.If(_testImageReference == null);
 
-            var containerRegistryTemplateProvider = new ContainerRegistryTemplateProvider(
+            ContainerRegistryTemplateProvider containerRegistryTemplateProvider = new ContainerRegistryTemplateProvider(
                 TestUtils.GetMockAcrTokenProvider("invalid token"),
                 new DiagnosticLogger(),
                 new NullLogger<ContainerRegistryTemplateProvider>());

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryTemplateProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/ContainerRegistry/ContainerRegistryTemplateProviderTests.cs
@@ -4,8 +4,10 @@
 // -------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using DotLiquid;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Health.Fhir.Synapse.Common.Logging;
 using Microsoft.Health.Fhir.Synapse.Core.UnitTests;
@@ -24,7 +26,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
 
         public ContainerRegistryTemplateProviderTests()
         {
-            var testContainerRegistryServer = Environment.GetEnvironmentVariable("TestContainerRegistryServer");
+            string testContainerRegistryServer = Environment.GetEnvironmentVariable("TestContainerRegistryServer");
             if (testContainerRegistryServer == null)
             {
                 return;
@@ -32,8 +34,8 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
 
             _testImageReference = $"{testContainerRegistryServer}/synapsetesttemplates:latest";
 
-            var testContainerRegistryUsername = Environment.GetEnvironmentVariable("TestContainerRegistryServer")?.Split('.')[0];
-            var testContainerRegistryPassword = Environment.GetEnvironmentVariable("TestContainerRegistryPassword");
+            string testContainerRegistryUsername = Environment.GetEnvironmentVariable("TestContainerRegistryServer")?.Split('.')[0];
+            string testContainerRegistryPassword = Environment.GetEnvironmentVariable("TestContainerRegistryPassword");
 
             _testContainerRegistryAccessToken = TestUtils.GetAcrAccessToken(testContainerRegistryUsername, testContainerRegistryPassword);
             _testTokenProvider = TestUtils.GetMockAcrTokenProvider(_testContainerRegistryAccessToken);
@@ -51,7 +53,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.ContainerRegi
                 _testTokenProvider,
                 new DiagnosticLogger(),
                 new NullLogger<ContainerRegistryTemplateProvider>());
-            var templateCollection = await containerRegistryTemplateProvider.GetTemplateCollectionAsync(_testImageReference, CancellationToken.None);
+            List<Dictionary<string, Template>> templateCollection = await containerRegistryTemplateProvider.GetTemplateCollectionAsync(_testImageReference, CancellationToken.None);
 
             Assert.NotEmpty(templateCollection);
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/FhirParquetSchemaManagerTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/FhirParquetSchemaManagerTests.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
@@ -18,9 +19,9 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
 
         static FhirParquetSchemaManagerTests()
         {
-            var schemaConfigurationOptionWithoutCustomizedSchema = Options.Create(new SchemaConfiguration());
+            IOptions<SchemaConfiguration> schemaConfigurationOptionWithoutCustomizedSchema = Options.Create(new SchemaConfiguration());
 
-            var schemaConfigurationOptionWithCustomizedSchema = Options.Create(new SchemaConfiguration()
+            IOptions<SchemaConfiguration> schemaConfigurationOptionWithCustomizedSchema = Options.Create(new SchemaConfiguration()
             {
                 EnableCustomizedSchema = true,
                 SchemaImageReference = TestUtils.MockSchemaImageReference,
@@ -37,7 +38,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
         [Theory]
         public static void GivenASchemaType_WhenGetSchema_CorrectResultShouldBeReturned(string schemaType, int propertyCount)
         {
-            var result = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchema(schemaType);
+            FhirParquetSchemaNode result = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchema(schemaType);
 
             Assert.Equal(schemaType, result.Name);
             Assert.False(result.IsLeaf);
@@ -47,23 +48,23 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
         [Fact]
         public static void GivenInvalidSchemaType_WhenGetSchema_NullShouldBeReturned()
         {
-            var schemaType = "InvalidSchemaType";
+            string schemaType = "InvalidSchemaType";
 
-            var result = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchema(schemaType);
+            FhirParquetSchemaNode result = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchema(schemaType);
             Assert.Null(result);
         }
 
         [Fact]
         public static void WhenGetAllSchemasWithoutCustomizedSchema_CorrectResultShouldBeReturned()
         {
-            var schemas = _testParquetSchemaManagerWithoutCustomizedSchema.GetAllSchemas();
+            Dictionary<string, FhirParquetSchemaNode> schemas = _testParquetSchemaManagerWithoutCustomizedSchema.GetAllSchemas();
             Assert.Equal(145, schemas.Count);
         }
 
         [Fact]
         public static void WhenGetAllSchemasWithCustomizedSchema_CorrectResultShouldBeReturned()
         {
-            var schemas = _testParquetSchemaManagerWithCustomizedSchema.GetAllSchemas();
+            Dictionary<string, FhirParquetSchemaNode> schemas = _testParquetSchemaManagerWithCustomizedSchema.GetAllSchemas();
 
             // Test customized schemas contain a "Patient_Customized" schema.
             Assert.Equal(146, schemas.Count);
@@ -76,7 +77,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
         [Theory]
         public static void GivenAResourceType_WhenGetSchemaTypesWithoutCustomizedSchema_CorrectResultShouldBeReturned(string resourceType)
         {
-            var schemaTypes = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchemaTypes(resourceType);
+            List<string> schemaTypes = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchemaTypes(resourceType);
             Assert.Single(schemaTypes);
             Assert.Equal(resourceType, schemaTypes[0]);
         }
@@ -84,7 +85,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
         [Fact]
         public static void GivenAResourceType_WhenGetSchemaTypesWithCustomizedSchema_CorrectResultShouldBeReturned()
         {
-            var schemaTypes = _testParquetSchemaManagerWithCustomizedSchema.GetSchemaTypes("Patient");
+            List<string> schemaTypes = _testParquetSchemaManagerWithCustomizedSchema.GetSchemaTypes("Patient");
             Assert.Equal(2, schemaTypes.Count);
             Assert.Contains<string>("Patient", schemaTypes);
             Assert.Contains<string>("Patient_Customized", schemaTypes);
@@ -93,9 +94,9 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet
         [Fact]
         public static void GivenInvalidResourceType_WhenGetSchemaTypes_EmptyResultShouldBeReturned()
         {
-            var resourceType = "InvalidResourceType";
+            string resourceType = "InvalidResourceType";
 
-            var schemaTypes = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchemaTypes(resourceType);
+            List<string> schemaTypes = _testParquetSchemaManagerWithoutCustomizedSchema.GetSchemaTypes(resourceType);
             Assert.Empty(schemaTypes);
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/AcrCustomizedSchemaProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/AcrCustomizedSchemaProviderTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
         {
             List<Dictionary<string, Template>> testSchemaTemplateCollections = TestUtils.GetSchemaTemplateCollections("Schema/Patient.schema.json", File.ReadAllBytes(TestUtils.TestJsonSchemaFilePath));
 
-            var schemaProvider = new AcrCustomizedSchemaProvider(
+            AcrCustomizedSchemaProvider schemaProvider = new AcrCustomizedSchemaProvider(
                 TestUtils.GetMockAcrTemplateProvider(testSchemaTemplateCollections),
                 Options.Create(_schemaConfigurationWithCustomizedSchema),
                 new DiagnosticLogger(),
@@ -53,7 +53,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
         public static async void GivenImageReference_WhenGetSchemaWithInvalidTemplateProvider_CorrectResultShouldBeReturned(string schemaKey)
         {
             List<Dictionary<string, Template>> testSchemaTemplateCollections = TestUtils.GetSchemaTemplateCollections(schemaKey, File.ReadAllBytes(TestUtils.TestJsonSchemaFilePath));
-            var schemaProvider = new AcrCustomizedSchemaProvider(
+            AcrCustomizedSchemaProvider schemaProvider = new AcrCustomizedSchemaProvider(
                 TestUtils.GetMockAcrTemplateProvider(testSchemaTemplateCollections),
                 Options.Create(_schemaConfigurationWithCustomizedSchema),
                 new DiagnosticLogger(),

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/JsonSchemaParserTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/JsonSchemaParserTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
         [MemberData(nameof(GetInvalidJsonSchemaContents))]
         public void GivenAInvalidJsonSchema_WhenParseJSchema_ExceptionsShouldBeThrown(JsonSchema jSchema)
         {
-            var schemaParser = new JsonSchemaParser();
+            JsonSchemaParser schemaParser = new JsonSchemaParser();
             Assert.Throws<GenerateFhirParquetSchemaNodeException>(() => JsonSchemaParser.ParseJSchema("testType", jSchema));
         }
     }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/JsonSchemaParserTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/JsonSchemaParserTests.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Health.Fhir.Synapse.SchemaManagement.Exceptions;
+using Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet;
 using Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -27,9 +28,9 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
         [Fact]
         public void GivenAJsonSchema_WhenParseJSchema_CorrectResultShouldBeReturned()
         {
-            var testSchema = JsonSchema.FromJsonAsync(File.ReadAllText(Path.Join(TestUtils.CustomizedTestSchemaDirectory, "ValidSchema.schema.json"))).GetAwaiter().GetResult();
-            var parquetSchemaNode = JsonSchemaParser.ParseJSchema("testType", testSchema);
-            var expectedSchemaNode = JsonSchema.FromJsonAsync(File.ReadAllText(Path.Join(TestUtils.ExpectedDataDirectory, "ExpectedValidParquetSchemaNode.json"))).GetAwaiter().GetResult();
+            JsonSchema testSchema = JsonSchema.FromJsonAsync(File.ReadAllText(Path.Join(TestUtils.CustomizedTestSchemaDirectory, "ValidSchema.schema.json"))).GetAwaiter().GetResult();
+            FhirParquetSchemaNode parquetSchemaNode = JsonSchemaParser.ParseJSchema("testType", testSchema);
+            JsonSchema expectedSchemaNode = JsonSchema.FromJsonAsync(File.ReadAllText(Path.Join(TestUtils.ExpectedDataDirectory, "ExpectedValidParquetSchemaNode.json"))).GetAwaiter().GetResult();
 
             Assert.True(JToken.DeepEquals(
                 JObject.Parse(JsonConvert.SerializeObject(parquetSchemaNode)),

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/LocalDefaultSchemaProviderTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/Parquet/SchemaProvider/LocalDefaultSchemaProviderTests.cs
@@ -3,10 +3,12 @@
 // Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // -------------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Health.Fhir.Synapse.Common.Configurations;
 using Microsoft.Health.Fhir.Synapse.Common.Logging;
+using Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet;
 using Microsoft.Health.Fhir.Synapse.SchemaManagement.Parquet.SchemaProvider;
 using Xunit;
 
@@ -31,7 +33,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests.Parquet.Schem
         [Theory]
         public static async void GivenSchemaDirectory_WhenGetSchema_CorrectResultShouldBeReturned(string schemaType, int propertyCount)
         {
-            var defaultSchemas = await _testLocalDefaultSchemaProvider.GetSchemasAsync();
+            Dictionary<string, FhirParquetSchemaNode> defaultSchemas = await _testLocalDefaultSchemaProvider.GetSchemasAsync();
 
             Assert.Equal(145, defaultSchemas.Count);
 

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestUtils.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestUtils.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests
 
         public static IContainerRegistryTokenProvider GetMockAcrTokenProvider(string accessToken)
         {
-            var tokenProvider = Substitute.For<IContainerRegistryTokenProvider>();
+            IContainerRegistryTokenProvider tokenProvider = Substitute.For<IContainerRegistryTokenProvider>();
 
             tokenProvider.GetTokenAsync(default, default).ReturnsForAnyArgs($"Basic {accessToken}");
             return tokenProvider;
@@ -41,7 +41,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests
 
         public static IContainerRegistryTemplateProvider GetMockAcrTemplateProvider(List<Dictionary<string, Template>> templateCollections)
         {
-            var templateProvider = Substitute.For<IContainerRegistryTemplateProvider>();
+            IContainerRegistryTemplateProvider templateProvider = Substitute.For<IContainerRegistryTemplateProvider>();
             templateProvider.GetTemplateCollectionAsync(default, default).ReturnsForAnyArgs(templateCollections);
             return templateProvider;
         }

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestUtils.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests/TestUtils.cs
@@ -53,15 +53,15 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests
 
         public static List<Dictionary<string, Template>> GetSchemaTemplateCollections(string schemaKey, byte[] schemaContent)
         {
-            var schemaContents = new Dictionary<string, byte[]> { { schemaKey, schemaContent } };
+            Dictionary<string, byte[]> schemaContents = new Dictionary<string, byte[]> { { schemaKey, schemaContent } };
 
-            var templateCollection = TemplateLayerParser.ParseToTemplates(schemaContents);
+            Dictionary<string, Template> templateCollection = TemplateLayerParser.ParseToTemplates(schemaContents);
             return new List<Dictionary<string, Template>> { templateCollection };
         }
 
         public static IParquetSchemaProvider TestParquetSchemaProviderDelegate(string name)
         {
-            var testSchemaTemplateCollections = GetSchemaTemplateCollections("Schema/Patient.schema.json", File.ReadAllBytes(TestJsonSchemaFilePath));
+            List<Dictionary<string, Template>> testSchemaTemplateCollections = GetSchemaTemplateCollections("Schema/Patient.schema.json", File.ReadAllBytes(TestJsonSchemaFilePath));
 
             if (name == FhirParquetSchemaConstants.DefaultSchemaProviderKey)
             {
@@ -72,7 +72,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.UnitTests
             }
             else
             {
-                var schemaConfigurationOptionWithCustomizedSchema = Options.Create(new SchemaConfiguration()
+                IOptions<SchemaConfiguration> schemaConfigurationOptionWithCustomizedSchema = Options.Create(new SchemaConfiguration()
                 {
                     EnableCustomizedSchema = true,
                     SchemaImageReference = MockSchemaImageReference,


### PR DESCRIPTION
1. replace `var` with the specified type.
2. fix code style issue.
3. fix the build warnings.