### PR TITLE
Decrease default job concurrency

### DIFF
--- a/FhirToDataLake/deploy/templates/DeployContainer.json
+++ b/FhirToDataLake/deploy/templates/DeployContainer.json
@@ -53,6 +53,13 @@
                 "description": "The name of the container to store job and data."
             }
         },
+        "jobConcurrency": {
+            "type": "string",
+            "defaultValue": "10",
+            "metadata": {
+                "description": "Concurrent jobs exeucting in parallel."
+            }
+        },
         "filterConfigImageReference":{
             "type": "string",
             "defaultValue": "",
@@ -276,6 +283,10 @@
                                 {
                                     "name": "job__metadataTableName",
                                     "value": "[variables('metadataTableName')]"
+                                },
+                                {
+                                    "name": "job__maxRunningJobCount",
+                                    "value": "[parameters('jobConcurrency')]"
                                 },
                                 {
                                     "name": "job__containerName",

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/JobConfiguration.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/JobConfiguration.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations
         /// <summary>
         /// Max running job count in an instance.
         /// </summary>
-        [JsonProperty("maxRunningJobCount ")]
-        public int MaxRunningJobCount { get; set; } = 10;
+        [JsonProperty("maxRunningJobCount")]
+        public int MaxRunningJobCount { get; set; } = 3;
 
         /// <summary>
         /// Max queued job count per orchestration job.

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/appsettings.json
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/appsettings.json
@@ -19,7 +19,7 @@
     "containerName": "",
     "startTime": "",
     "endTime": "",
-    "maxRunningJobCount": 10,
+    "maxRunningJobCount": 3,
     "maxQueuedJobCountPerOrchestration": 100
   },
   "filter": {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/appsettings.json
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/appsettings.json
@@ -19,7 +19,7 @@
     "containerName": "",
     "startTime": "",
     "endTime": "",
-    "maxRunningJobCount": 10,
+    "maxRunningJobCount": 3,
     "maxQueuedJobCountPerOrchestration": 100
   },
   "filter": {

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/appsettings.test.json
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.E2ETests/appsettings.test.json
@@ -18,7 +18,7 @@
     "containerName": "test",
     "startTime": "1970-01-01T00:00:00.000Z",
     "endTime": "2022-07-01T00:00:00.000Z",
-    "maxRunningJobCount": 10,
+    "maxRunningJobCount": 3,
     "maxQueuedJobCountPerOrchestration": 100
   },
   "filter": {


### PR DESCRIPTION
The default job concurrency may bring heavy CPU and memory pressure when the hosting machine is not very powerful. A lower single-node concurrency is also aligned with our target to scale out to multiple nodes in the future. So we currently decrease the default value and customer can set it during deployment template.
