### PR TITLE
Refine health check

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/HealthCheckConfiguration.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Configurations/HealthCheckConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common.Configurations
         /// The timeout to use for a single health check
         /// </summary>
         [JsonProperty("healthCheckTimeoutInSeconds")]
-        public int HealthCheckTimeoutInSeconds { get; set; } = 60;
+        public int HealthCheckTimeoutInSeconds { get; set; } = 100;
 
         /// <summary>
         /// Time interval for health check.

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Resource.Designer.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Resource.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resource {
@@ -70,7 +70,7 @@ namespace Microsoft.Health.Fhir.Synapse.Common {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Search FHIR server failed. Search url: &apos;{0}&apos;. .
+        ///   Looks up a localized string similar to Search FHIR server failed. Search url: &apos;{0}&apos;. Reason : {1} .
         /// </summary>
         public static string FhirSearchFailed {
             get {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Resource.resx
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Common/Resource.resx
@@ -122,8 +122,8 @@
     <comment>{0}: failed reason.</comment>
   </data>
   <data name="FhirSearchFailed" xml:space="preserve">
-    <value>Search FHIR server failed. Search url: '{0}'. </value>
-    <comment>{0}: url used to query FHIR server.</comment>
+    <value>Search FHIR server failed. Search url: '{0}'. Reason : {1} </value>
+    <comment>{0}: url used to query FHIR server. {1}: failed reason</comment>
   </data>
   <data name="FhirSearchFailureCode" xml:space="preserve">
     <value>Search FHIR server failed. Search url: '{0}'. Status code: '{1}'.</value>

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/ContainerRegistryFilterProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataFilter/ContainerRegistryFilterProvider.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataFilter
                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     onRetry: (exception, timeSpan, retryCount, context) =>
                     {
-                        _logger.LogWarning(exception, "Failed to get image {Image} from Container Registry. Retry {RetryCount}.", _imageReference, retryCount);
+                        _logger.LogInformation(exception, "Failed to get image {Image} from Container Registry. Retry {RetryCount}.", _imageReference, retryCount);
                     })
                   .ExecuteAsync(() => filterConfigurationProvider.GetOciArtifactAsync(cancellationToken));
 

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
@@ -214,13 +214,13 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
                         _logger.LogInformation(hrEx, "Failed to search from FHIR server: FHIR server {0} is not found.", _dataSource.FhirServerUrl);
                         break;
                     default:
-                        _diagnosticLogger.LogError(string.Format("Failed to search from FHIR server: Status code: {0}.", hrEx.StatusCode));
-                        _logger.LogInformation(hrEx, "Failed to search from FHIR server: Status code: {0}.", hrEx.StatusCode);
+                        _diagnosticLogger.LogError(string.Format("Failed to search from FHIR server: Status code: {0}. Reason: {1}", hrEx.StatusCode, hrEx.Message));
+                        _logger.LogInformation(hrEx, "Failed to search from FHIR server: Status code: {0}. Reason: {1}", hrEx.StatusCode, hrEx.Message);
                         break;
                 }
 
                 throw new FhirSearchException(
-                    string.Format(Resource.FhirSearchFailed, uri),
+                    string.Format(Resource.FhirSearchFailed, uri) + $"Reason:{hrEx.Message}",
                     hrEx);
             }
             catch (BrokenCircuitException bcEx)
@@ -229,7 +229,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
                 _logger.LogInformation(bcEx, "Broken circuit while searching from FHIR server. Reason: {0}", bcEx.Message);
 
                 throw new FhirSearchException(
-                    string.Format(Resource.FhirSearchFailed, uri),
+                    string.Format(Resource.FhirSearchFailed, uri) + $"Reason:{bcEx.Message}",
                     bcEx);
             }
             catch (Exception ex)
@@ -268,13 +268,13 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
                         _logger.LogInformation(ex, "Failed to search from FHIR server: FHIR server {0} is not found.", _dataSource.FhirServerUrl);
                         break;
                     default:
-                        _diagnosticLogger.LogError(string.Format("Failed to search from FHIR server: Status code: {0}.", ex.StatusCode));
-                        _logger.LogInformation(ex, "Failed to search from FHIR server: Status code: {0}.", ex.StatusCode);
+                        _diagnosticLogger.LogError(string.Format("Failed to search from FHIR server: Status code: {0}. Reason: {1}", ex.StatusCode, ex.Message));
+                        _logger.LogInformation(ex, "Failed to search from FHIR server: Status code: {0}. Reason: {1}", ex.StatusCode, ex.Message);
                         break;
                 }
 
                 throw new FhirSearchException(
-                    string.Format(Resource.FhirSearchFailed, uri),
+                    string.Format(Resource.FhirSearchFailed, uri) + $"Reason:{ex.Message}",
                     ex);
             }
             catch (Exception ex)

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.DataClient/Api/FhirApiDataClient.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
                 }
 
                 throw new FhirSearchException(
-                    string.Format(Resource.FhirSearchFailed, uri) + $"Reason:{hrEx.Message}",
+                    string.Format(Resource.FhirSearchFailed, uri, hrEx.Message),
                     hrEx);
             }
             catch (BrokenCircuitException bcEx)
@@ -229,7 +229,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
                 _logger.LogInformation(bcEx, "Broken circuit while searching from FHIR server. Reason: {0}", bcEx.Message);
 
                 throw new FhirSearchException(
-                    string.Format(Resource.FhirSearchFailed, uri) + $"Reason:{bcEx.Message}",
+                    string.Format(Resource.FhirSearchFailed, uri, bcEx.Message),
                     bcEx);
             }
             catch (Exception ex)
@@ -274,7 +274,7 @@ namespace Microsoft.Health.Fhir.Synapse.DataClient.Api
                 }
 
                 throw new FhirSearchException(
-                    string.Format(Resource.FhirSearchFailed, uri) + $"Reason:{ex.Message}",
+                    string.Format(Resource.FhirSearchFailed, uri, ex.Message),
                     ex);
             }
             catch (Exception ex)

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/appsettings.json
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.FunctionApp/appsettings.json
@@ -45,7 +45,7 @@
     "schemaImageReference": ""
   },
   "healthCheck": {
-    "healthCheckTimeoutInSeconds": 60,
+    "healthCheckTimeoutInSeconds": 100,
     "healthCheckTimeIntervalInSeconds": 120
   },
   "storage": {

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryTemplateProvider.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.SchemaManagement/ContainerRegistry/ContainerRegistryTemplateProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Health.Fhir.Synapse.SchemaManagement.ContainerRegistry
                     retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     onRetry: (exception, timeSpan, retryCount, context) =>
                     {
-                        _logger.LogWarning(exception, "Failed to get template collection from {Image}. Retry {RetryCount}.", schemaImageReference, retryCount);
+                        _logger.LogInformation(exception, "Failed to get template collection from {Image}. Retry {RetryCount}.", schemaImageReference, retryCount);
                     })
                   .ExecuteAsync(() => provider.GetTemplateCollectionAsync(cancellationToken));
             }

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/appsettings.json
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Tool/appsettings.json
@@ -45,7 +45,7 @@
     "schemaImageReference": ""
   },
   "healthCheck": {
-    "healthCheckTimeoutInSeconds": 60,
+    "healthCheckTimeoutInSeconds": 100,
     "healthCheckTimeIntervalInSeconds": 120
   },
   "storage": {


### PR DESCRIPTION
1. Change health check timeout from 60 to 100 seconds.
2. Refine message in FHIR server client to make health checker's log clearer.
