### PR TITLE
Exclude data files for scanning

### DIFF
--- a/GeoPol.xml
+++ b/GeoPol.xml
@@ -23,5 +23,7 @@
     <ExcludeFolder>FhirToCdm\Configuration-Generator\fhir.schema.json</ExcludeFolder>
     <ExcludeFolder>FhirToCdm\Microsoft.Health.Fhir.Transformation.Cdm.Test</ExcludeFolder>
     <ExcludeFolder>FhirToCdm\Microsoft.Health.Fhir.Transformation.Core.Test</ExcludeFolder>
+    <ExcludeFolder>FhirToDataLake\data\</ExcludeFolder>
+    <ExcludeFolder>FhirToDataLake\scripts\sql\</ExcludeFolder>
   </Component>
 </GeoPol_Folders>


### PR DESCRIPTION
There are some sample data files that are defined by FHIR standard. These files are not sensitive and should not be scanned.