### PR TITLE
Update ParquetNative Version

### DIFF
--- a/FhirToDataLake/Directory.Build.props
+++ b/FhirToDataLake/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <ParquetNativeLibVersion>1.0.0.68</ParquetNativeLibVersion>
+    <ParquetNativeLibVersion>1.0.0.215</ParquetNativeLibVersion>
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" Link="stylecop.json" />


### PR DESCRIPTION
The FhirServer public feed doesn't have our current version, in my local environment, will auto-pull an incorrect version that have compatibility issue.