### PR TITLE
Keep Raw TimeStamp String In DICOM Parquet

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/DicomToDataLakeProcessingJob.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/DicomToDataLakeProcessingJob.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
 {
     public class DicomToDataLakeProcessingJob : IJob
     {
+        private readonly JsonSerializerSettings _jsonSerializerSettings;
         private readonly DicomToDataLakeProcessingJobInputData _inputData;
         private readonly IApiDataClient _dataClient;
         private readonly IDataWriter _dataWriter;
@@ -78,6 +79,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             _metricsLogger = EnsureArg.IsNotNull(metricsLogger, nameof(metricsLogger));
             _diagnosticLogger = EnsureArg.IsNotNull(diagnosticLogger, nameof(diagnosticLogger));
             _logger = EnsureArg.IsNotNull(logger, nameof(logger));
+
+            _jsonSerializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
         }
 
         // the processing job status is never set to failed or cancelled.
@@ -284,7 +287,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
             List<JObject> metadataObjects;
             try
             {
-                metadataObjects = JArray.Parse(changeFeedsContent)
+                metadataObjects = JsonConvert.DeserializeObject<JArray>(changeFeedsContent, _jsonSerializerSettings)
                     .Where(changeFeed =>
                         Enum.Parse<ChangeFeedState>(changeFeed[DicomChangeFeedConstants.StateKey].ToString(), true) == ChangeFeedState.Current &&
                         Enum.Parse<ChangeFeedAction>(changeFeed[DicomChangeFeedConstants.ActionKey].ToString(), true) == ChangeFeedAction.Create)

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/DicomToDataLakeProcessingJobTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/Jobs/DicomToDataLakeProcessingJobTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.Jobs
             Assert.Equal(3, result.SearchCount["Dicom"]);
             Assert.Equal(3, result.ProcessedCount["Dicom"]);
             Assert.Equal(0, result.SkippedCount["Dicom"]);
-            Assert.Equal(911016, result.ProcessedDataSizeInTotal);
+            Assert.Equal(911130, result.ProcessedDataSizeInTotal);
             Assert.Equal(3, result.ProcessedCountInTotal);
 
             await Task.Delay(TimeSpan.FromMilliseconds(100));


### PR DESCRIPTION
Keep the raw timeStamp strin value in DICOM Parquet data.