### PR TITLE
Handle empty invalid change feed

### DIFF
--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataProcessor/ParquetDataProcessor.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/DataProcessor/ParquetDataProcessor.cs
@@ -109,8 +109,8 @@ namespace Microsoft.Health.Fhir.Synapse.Core.DataProcessor
                          .Where(result => CheckBlockSize(processParameters.SchemaType, result)));
             if (string.IsNullOrEmpty(inputContent))
             {
-                // Return null if no data has been converted.
-                return Task.FromResult<StreamBatchData>(null);
+                // Return StreamBatchData with null Value if no data has been converted.
+                return Task.FromResult<StreamBatchData>(new StreamBatchData(null, 0, processParameters.SchemaType));
             }
 
             // Convert JSON data to parquet stream.

--- a/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/DicomToDataLakeProcessingJob.cs
+++ b/FhirToDataLake/src/Microsoft.Health.Fhir.Synapse.Core/Jobs/DicomToDataLakeProcessingJob.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Health.Fhir.Synapse.Core.Jobs
                 throw new ApiSearchException("Parse metadata objects failed.", ex);
             }
 
-            return new SearchResult(metadataObjects, changeFeedsContent.Length, null);
+            return new SearchResult(metadataObjects, changeFeedsContent.Length * sizeof(char), null);
         }
 
         /// <summary>

--- a/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/ParquetDataProcessorTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.Fhir.Synapse.Core.UnitTests/DataProcessor/ParquetDataProcessorTests.cs
@@ -236,7 +236,9 @@ namespace Microsoft.Health.Fhir.Synapse.Core.UnitTests.DataProcessor
             var jsonBatchData = new JsonBatchData(testData);
 
             StreamBatchData result = await parquetDataProcessor.ProcessAsync(jsonBatchData, new ProcessParameters("Patient", "Patient"));
-            Assert.Null(result);
+            Assert.Null(result.Value);
+            Assert.Equal(0, result.BatchSize);
+            Assert.Equal("Patient", result.SchemaType);
         }
 
         [Fact]


### PR DESCRIPTION
1. Handle empty invalid change feed, which means all change feeds are replaced or deleted.
2. Add tests for that. 