### PR TITLE
Fix CI Download Artifact Task

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -1,15 +1,15 @@
 steps:
-- task: DownloadBuildArtifacts@0
+- task: DownloadPipelineArtifact@2
   displayName: 'Download FhirToDataLake Image Artifacts'
   inputs:
     artifactName: FhirToDataLakeImage
-    downloadPath: $(System.DefaultWorkingDirectory)
+    downloadPath: $(System.DefaultWorkingDirectory)/FhirToDataLakeImage
 
-- task: DownloadBuildArtifacts@0
+- task: DownloadPipelineArtifact@2
   displayName: 'Download FhirToDataLake Function App Artifacts'
   inputs:
     artifactName: FhirToDataLakeFunctionApp
-    downloadPath: $(System.DefaultWorkingDirectory)
+    downloadPath: $(System.DefaultWorkingDirectory)/FhirToDataLakeFunctionApp
 
 - task: DownloadBuildArtifacts@0
   displayName: 'Download FhirToCdm Artifacts'


### PR DESCRIPTION
The FhirToDatalake image and function app artifacts are uploaded to CI as pipeline artifacts, we should use **DownloadPipelineArtifact** to download them in _publish_ stage.