### PR TITLE
Fix the image clean up dependency

### DIFF
--- a/FhirToDataLake/azurepipelines/OverallTest/clean-environment.yml
+++ b/FhirToDataLake/azurepipelines/OverallTest/clean-environment.yml
@@ -1,0 +1,28 @@
+steps:
+- task: AzureKeyVault@2
+  inputs:
+    azureSubscription: 'ResoluteOpenSource'
+    KeyVaultName: $(keyVaultName)
+    SecretsFilter: '*'
+    RunAsPreJob: false
+
+- task: AzurePowerShell@5
+  displayName: Clean up image on test ACR
+  inputs:
+    azureSubscription: ResoluteOpenSource
+    azurePowerShellVersion: latestVersion
+    ScriptType: inlineScript
+    pwsh: true
+    Inline: |
+      try
+      {
+        Remove-AzContainerRegistryRepository -Name $(imageName) -RegistryName ($env:CONTAINER_REGISTRY_SERVER -split '.', 0, "simplematch")[0]
+        Write-Host "##[section]Clear test image"
+      }
+      catch [Exception]
+      {
+        Write-Host "##[warning] $($_.Exception.Message)"
+      }
+  env:
+    CONTAINER_REGISTRY_SERVER: $(pipeline-container-registry-server)
+

--- a/FhirToDataLake/azurepipelines/OverallTest/dicomtosynapse-e2e-test.yml
+++ b/FhirToDataLake/azurepipelines/OverallTest/dicomtosynapse-e2e-test.yml
@@ -170,16 +170,6 @@ steps:
       Remove-AzStorageQueue -Name $(containerName)jobinfoqueue -Context $storageContext -Force
       Write-Host "##[section]Clear test container"
 
-      try
-      {
-        Remove-AzContainerRegistryRepository -Name $(imageName) -RegistryName ($env:CONTAINER_REGISTRY_SERVER -split '.', 0, "simplematch")[0]
-        Write-Host "##[section]Clear test image"
-      }
-      catch [Exception]
-      {
-        Write-Host "##[warning] $($_.Exception.Message)"
-      }
-
       $sqlServerEndpoint = "$(synapseWorkspaceName)-ondemand.sql.azuresynapse.net"
       $userName = $env:SQL_USERNAME
       $password = $env:SQL_PASSWORD
@@ -221,6 +211,5 @@ steps:
         }
       } while ($attempts -le $maxAttempts)
   env:
-    CONTAINER_REGISTRY_SERVER: $(pipeline-container-registry-server)
     SQL_USERNAME: $(synapse-sql-username)
     SQL_PASSWORD: $(synapse-sql-password)

--- a/FhirToDataLake/azurepipelines/OverallTest/fhirtosynapse-e2e-test.yml
+++ b/FhirToDataLake/azurepipelines/OverallTest/fhirtosynapse-e2e-test.yml
@@ -174,16 +174,6 @@ steps:
       Remove-AzStorageQueue -Name $(containerName)jobinfoqueue -Context $storageContext -Force
       Write-Host "##[section]Clear test container"
 
-      try
-      {
-        Remove-AzContainerRegistryRepository -Name $(imageName) -RegistryName ($env:CONTAINER_REGISTRY_SERVER -split '.', 0, "simplematch")[0]
-        Write-Host "##[section]Clear test image"
-      }
-      catch [Exception]
-      {
-        Write-Host "##[warning] $($_.Exception.Message)"
-      }
-
       $sqlServerEndpoint = "$(synapseWorkspaceName)-ondemand.sql.azuresynapse.net"
       $userName = $env:SQL_USERNAME
       $password = $env:SQL_PASSWORD
@@ -225,6 +215,5 @@ steps:
         }
       } while ($attempts -le $maxAttempts)
   env:
-    CONTAINER_REGISTRY_SERVER: $(pipeline-container-registry-server)
     SQL_USERNAME: $(synapse-sql-username)
     SQL_PASSWORD: $(synapse-sql-password)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,15 @@ stages:
     steps:
     - template: FhirToDataLake/azurepipelines/OverallTest/dicomtosynapse-e2e-test.yml
 
+  - job: CleanTestEnvironment
+    dependsOn:
+    - RunFhirToSynapseOverallTest
+    - RunDicomToSynapseOverallTest
+    pool:
+      vmImage: 'ubuntu-22.04'
+    steps:
+    - template: FhirToDataLake/azurepipelines/OverallTest/clean-environment.yml
+
 - stage: Release
   condition: succeeded()
   pool:


### PR DESCRIPTION
The FhirToDatalake overall test and DicomToDatalake overall test both will try to delete the test image after finishing, one of them may delete the test image when another overall test still need it.

Refine the CI logic, cleaning up the test image after DICOM and FHIR overall tests all finished.