### PR TITLE
Update native nuget package with runtime identifier

### DIFF
--- a/FhirToDataLake/azurepipelines/native/nativeci.yml
+++ b/FhirToDataLake/azurepipelines/native/nativeci.yml
@@ -29,7 +29,7 @@ stages:
     - template: build-windows-native-libs.yml
 
 - stage: PublishNuget
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+  condition: succeeded()
   jobs:
   - job: PackNugets
     pool:

--- a/FhirToDataLake/native/parquet/csharp/src/Microsoft.Health.Parquet.targets
+++ b/FhirToDataLake/native/parquet/csharp/src/Microsoft.Health.Parquet.targets
@@ -1,15 +1,27 @@
 <?xml version="1.0"?>
 <Project>
-    <ItemGroup Condition=" '$(OS)' == 'WINDOWS_NT'">
-        <Content Include="$(MSBuildThisFileDirectory)..\runtimes\windows-x64\*.dll">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>%(FileName)%(Extension)</Link>
-        </Content>
-    </ItemGroup>
-    <ItemGroup Condition=" '$(OS)' == 'UNIX'">
-        <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\*">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>%(FileName)%(Extension)</Link>
-        </Content>
-    </ItemGroup>
+	<ItemGroup Condition="$(RuntimeIdentifier) == '' And $(OS) == 'Windows_NT'">
+		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\windows-x64\*.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>%(FileName)%(Extension)</Link>
+		</Content>
+	</ItemGroup>
+	<ItemGroup Condition="$(RuntimeIdentifier) == '' And $(OS) == 'UNIX'">
+		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\*">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>%(FileName)%(Extension)</Link>
+		</Content>
+	</ItemGroup>
+	<ItemGroup Condition="$(RuntimeIdentifier.StartsWith('win'))">
+		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\windows-x64\*.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>%(FileName)%(Extension)</Link>
+		</Content>
+	</ItemGroup>
+	<ItemGroup Condition="$(RuntimeIdentifier.StartsWith('linux'))">
+		<Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\*">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>%(FileName)%(Extension)</Link>
+		</Content>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Currently the native dependencies will be copied to output according to OS types. When users build from Windows targeting `linux-x64`, the output will still be windows dependencies. We add condition with runtime identifiers to build correct binaries.