### PR TITLE
Add Delay In Dicom Schedular Server Test

### DIFF
--- a/FhirToDataLake/test/Microsoft.Health.AnalyticsConnector.Core.UnitTests/Jobs/DicomToDatalakeSchedulerServiceTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.AnalyticsConnector.Core.UnitTests/Jobs/DicomToDatalakeSchedulerServiceTests.cs
@@ -179,6 +179,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
 
             using var tokenSource = new CancellationTokenSource();
 
+            // the deplay time should be larger than 2*"SchedulerServicePullingIntervalInSeconds" and with some buffer time.
             tokenSource.CancelAfter(TimeSpan.FromSeconds(4));
             Exception exception = await Record.ExceptionAsync(async () => await schedulerService.RunAsync(tokenSource.Token));
 
@@ -209,6 +210,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
 
             using var tokenSource = new CancellationTokenSource();
 
+            // the deplay time should be larger than 2*"SchedulerServicePullingIntervalInSeconds" and with some buffer time.
             tokenSource.CancelAfter(TimeSpan.FromSeconds(3));
             Exception exception = await Record.ExceptionAsync(async () => await schedulerService.RunAsync(tokenSource.Token));
 
@@ -1418,6 +1420,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             TriggerLeaseEntity triggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);
             Assert.NotNull(triggerLeaseEntity);
 
+            // the deplay time should be larger than 2*"SchedulerServicePullingIntervalInSeconds" and with some buffer time.
             await Task.Delay(TimeSpan.FromSeconds(4), CancellationToken.None);
 
             TriggerLeaseEntity newTriggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);

--- a/FhirToDataLake/test/Microsoft.Health.AnalyticsConnector.Core.UnitTests/Jobs/DicomToDatalakeSchedulerServiceTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.AnalyticsConnector.Core.UnitTests/Jobs/DicomToDatalakeSchedulerServiceTests.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
 
             using var tokenSource = new CancellationTokenSource();
 
-            tokenSource.CancelAfter(TimeSpan.FromSeconds(2));
+            tokenSource.CancelAfter(TimeSpan.FromSeconds(3));
             Exception exception = await Record.ExceptionAsync(async () => await schedulerService.RunAsync(tokenSource.Token));
 
             Assert.Null(exception);
@@ -238,7 +238,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
 
             using var tokenSource = new CancellationTokenSource();
 
-            tokenSource.CancelAfter(TimeSpan.FromSeconds(2));
+            tokenSource.CancelAfter(TimeSpan.FromSeconds(3));
             Exception exception = await Record.ExceptionAsync(async () => await schedulerService.RunAsync(tokenSource.Token));
 
             Assert.Null(exception);
@@ -595,7 +595,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             using var tokenSource = new CancellationTokenSource();
             Task task = schedulerService.RunAsync(tokenSource.Token);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None);
 
             // trigger lease entity is added
             TriggerLeaseEntity triggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);
@@ -627,7 +627,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             using var tokenSource = new CancellationTokenSource();
             Task task = schedulerService.RunAsync(tokenSource.Token);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None);
 
             // should enqueue orchestrator job
             CurrentTriggerEntity currentTriggerEntity = await metadataStore.GetCurrentTriggerEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);
@@ -988,7 +988,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             using var tokenSource = new CancellationTokenSource();
             Task task = schedulerService.RunAsync(tokenSource.Token);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None);
 
             CurrentTriggerEntity currentTriggerEntity = await metadataStore.GetCurrentTriggerEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);
             Assert.Equal(triggerEntity.TriggerSequenceId + 1, currentTriggerEntity.TriggerSequenceId);
@@ -1023,7 +1023,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             using var tokenSource = new CancellationTokenSource();
             Task task = schedulerService.RunAsync(tokenSource.Token);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None);
 
             // should enqueue orchestrator job
             CurrentTriggerEntity currentTriggerEntity = await metadataStore.GetCurrentTriggerEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);
@@ -1089,7 +1089,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             Task task1 = schedulerService.RunAsync(tokenSource1.Token);
 
             // should enqueue orchestrator job
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None);
 
             CurrentTriggerEntity currentTriggerEntity = await metadataStore.GetCurrentTriggerEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);
 
@@ -1418,7 +1418,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             TriggerLeaseEntity triggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);
             Assert.NotNull(triggerLeaseEntity);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(4), CancellationToken.None);
 
             TriggerLeaseEntity newTriggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);
             Assert.NotNull(newTriggerLeaseEntity);
@@ -1466,7 +1466,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             using var tokenSource = new CancellationTokenSource();
             Task task = schedulerService.RunAsync(tokenSource.Token);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None);
 
             // should enqueue orchestrator job
             CurrentTriggerEntity currentTriggerEntity = await metadataStore.GetCurrentTriggerEntityAsync((byte)QueueType.DicomToDataLake, CancellationToken.None);

--- a/FhirToDataLake/test/Microsoft.Health.AnalyticsConnector.Core.UnitTests/Jobs/FhirToDatalakeSchedulerServiceTests.cs
+++ b/FhirToDataLake/test/Microsoft.Health.AnalyticsConnector.Core.UnitTests/Jobs/FhirToDatalakeSchedulerServiceTests.cs
@@ -531,7 +531,8 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             TriggerLeaseEntity triggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.FhirToDataLake, CancellationToken.None);
             Assert.NotNull(triggerLeaseEntity);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            // the deplay time should be larger than 2*"SchedulerServicePullingIntervalInSeconds" and with some buffer time.
+            await Task.Delay(TimeSpan.FromSeconds(4), CancellationToken.None);
 
             TriggerLeaseEntity newTriggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.FhirToDataLake, CancellationToken.None);
             Assert.NotNull(newTriggerLeaseEntity);
@@ -614,7 +615,8 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             using var tokenSource = new CancellationTokenSource();
             Task task = schedulerService.RunAsync(tokenSource.Token);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            // the deplay time should be larger than 2*"SchedulerServicePullingIntervalInSeconds" and with some buffer time.
+            await Task.Delay(TimeSpan.FromSeconds(3), CancellationToken.None);
 
             // should enqueue orchestrator job
             CurrentTriggerEntity currentTriggerEntity = await metadataStore.GetCurrentTriggerEntityAsync((byte)QueueType.FhirToDataLake, CancellationToken.None);
@@ -1541,7 +1543,7 @@ namespace Microsoft.Health.AnalyticsConnector.Core.UnitTests.Jobs
             TriggerLeaseEntity triggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.FhirToDataLake, CancellationToken.None);
             Assert.NotNull(triggerLeaseEntity);
 
-            await Task.Delay(TimeSpan.FromSeconds(2), CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(4), CancellationToken.None);
 
             TriggerLeaseEntity newTriggerLeaseEntity = await metadataStore.GetTriggerLeaseEntityAsync((byte)QueueType.FhirToDataLake, CancellationToken.None);
             Assert.NotNull(newTriggerLeaseEntity);


### PR DESCRIPTION
Add delay in Dicom Schedular Server unit test as in CI, the server may not have enough time to finish the job.